### PR TITLE
ci: add 'release' type into rules

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -14,3 +14,17 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v4.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            release


### PR DESCRIPTION

## Description
ci: add 'release' type into rules

### Rationale
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/25412254/209491784-2f8f1c28-f5f6-40af-9403-fab73ebddda6.png">
https://github.com/amannn/action-semantic-pull-request

'release' is not in standard types of `ction-semantic-pull-request`

### Example

N/A

### Changes
Notable changes: 
* ci

