### PR TITLE
fix: disable create validator operation

### DIFF
--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -17,6 +17,9 @@ FROM alpine AS run
 RUN apk add bash curl jq libstdc++
 COPY contrib/images/simd-env/wrapper.sh /usr/bin/wrapper.sh
 
+ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
+
 VOLUME /simd
 COPY --from=build /work/build/simd /simd/
 WORKDIR /simd

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -286,8 +286,9 @@ func TestAppSimulationAfterImport(t *testing.T) {
 // TODO: Make another test for the fuzzer itself, which just has noOp txs
 // and doesn't depend on the application.
 func TestAppStateDeterminism(t *testing.T) {
-	// TODO skip first, Keefe fix it later
-	t.Skip("skipping application simulation")
+	if !FlagEnabledValue {
+		t.Skip("skipping application simulation")
+	}
 
 	config := NewConfigFromFlags()
 	config.InitialBlockHeight = 1

--- a/types/address.go
+++ b/types/address.go
@@ -80,6 +80,7 @@ const (
 
 	// BLSPubKeyLength defines a valid BLS Public key length
 	BLSPubKeyLength = 48
+	BLSEmptyPubKey  = "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000dead"
 )
 
 // cache variables

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -19,7 +19,6 @@ import (
 
 // Simulation operation weights constants
 const (
-	OpWeightMsgCreateValidator           = "op_weight_msg_create_validator"            //nolint:gosec
 	OpWeightMsgEditValidator             = "op_weight_msg_edit_validator"              //nolint:gosec
 	OpWeightMsgDelegate                  = "op_weight_msg_delegate"                    //nolint:gosec
 	OpWeightMsgUndelegate                = "op_weight_msg_undelegate"                  //nolint:gosec
@@ -33,18 +32,11 @@ func WeightedOperations(
 	bk types.BankKeeper, k keeper.Keeper,
 ) simulation.WeightedOperations {
 	var (
-		weightMsgCreateValidator           int
 		weightMsgEditValidator             int
 		weightMsgDelegate                  int
 		weightMsgUndelegate                int
 		weightMsgBeginRedelegate           int
 		weightMsgCancelUnbondingDelegation int
-	)
-
-	appParams.GetOrGenerate(cdc, OpWeightMsgCreateValidator, &weightMsgCreateValidator, nil,
-		func(_ *rand.Rand) {
-			weightMsgCreateValidator = simappparams.DefaultWeightMsgCreateValidator
-		},
 	)
 
 	appParams.GetOrGenerate(cdc, OpWeightMsgEditValidator, &weightMsgEditValidator, nil,
@@ -78,10 +70,6 @@ func WeightedOperations(
 	)
 
 	return simulation.WeightedOperations{
-		simulation.NewWeightedOperation(
-			weightMsgCreateValidator,
-			SimulateMsgCreateValidator(ak, bk, k),
-		),
 		simulation.NewWeightedOperation(
 			weightMsgEditValidator,
 			SimulateMsgEditValidator(ak, bk, k),
@@ -229,10 +217,7 @@ func SimulateMsgEditValidator(ak types.AccountKeeper, bk types.BankKeeper, k kee
 			simtypes.RandStringOfLength(r, 10),
 		)
 
-		blsSecretKey, _ := bls.RandKey()
-		blsPk := hex.EncodeToString(blsSecretKey.PublicKey().Marshal())
-
-		msg := types.NewMsgEditValidator(address, description, &newCommissionRate, nil, sdk.AccAddress(address), blsPk)
+		msg := types.NewMsgEditValidator(address, description, &newCommissionRate, nil, sdk.AccAddress(address), "")
 
 		txCtx := simulation.OperationInput{
 			R:               r,

--- a/x/staking/simulation/operations_test.go
+++ b/x/staking/simulation/operations_test.go
@@ -47,7 +47,6 @@ func TestWeightedOperations(t *testing.T) {
 		opMsgRoute string
 		opMsgName  string
 	}{
-		{simappparams.DefaultWeightMsgCreateValidator, types.ModuleName, types.TypeMsgCreateValidator},
 		{simappparams.DefaultWeightMsgEditValidator, types.ModuleName, types.TypeMsgEditValidator},
 		{simappparams.DefaultWeightMsgDelegate, types.ModuleName, types.TypeMsgDelegate},
 		{simappparams.DefaultWeightMsgUndelegate, types.ModuleName, types.TypeMsgUndelegate},

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -2,13 +2,13 @@ package types
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
 	"cosmossdk.io/math"
-	"github.com/prysmaticlabs/prysm/crypto/bls"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmprotocrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 	"sigs.k8s.io/yaml"
@@ -48,7 +48,7 @@ func NewSimpleValidator(operator sdk.ValAddress, pubKey cryptotypes.PubKey, desc
 		return Validator{}, err
 	}
 
-	blsSk, err := bls.RandKey()
+	blsPk, err := hex.DecodeString(sdk.BLSEmptyPubKey)
 	if err != nil {
 		return Validator{}, err
 	}
@@ -67,7 +67,7 @@ func NewSimpleValidator(operator sdk.ValAddress, pubKey cryptotypes.PubKey, desc
 		MinSelfDelegation: sdk.OneInt(),
 		SelfDelAddress:    operator.String(),
 		RelayerAddress:    operator.String(),
-		RelayerBlsKey:     blsSk.PublicKey().Marshal(),
+		RelayerBlsKey:     blsPk,
 	}, nil
 }
 

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -21,8 +21,7 @@ import (
 func TestValidatorTestEquivalent(t *testing.T) {
 	val1 := newValidator(t, valAddr1, pk1)
 	val2 := newValidator(t, valAddr1, pk1)
-	// When call newValidator, its bls pubkey is generated randomly
-	require.NotEqual(t, val1.String(), val2.String())
+	require.Equal(t, val1.String(), val2.String())
 
 	val2 = newValidator(t, valAddr2, pk2)
 	require.NotEqual(t, val1.String(), val2.String())


### PR DESCRIPTION
### Description

Disable the create validator operation when simulating weighted operations.

### Rationale

Create validators is now allowed for the common tx, we have made create validators by governance, so the original test cases won't pass.

### Example

NA

### Changes

Notable changes:
* disable create validator operation