### PR TITLE
fix: EIP712 issue with uint8[] type

### DIFF
--- a/x/auth/tx/eip712.go
+++ b/x/auth/tx/eip712.go
@@ -453,6 +453,9 @@ func traverseFields(
 			// Support array of uint64
 			if isCollection && fieldType.Kind() != reflect.Slice && fieldType.Kind() != reflect.Array {
 				ethTyp += "[]"
+				if ethTyp == "uint8[]" {
+					ethTyp = "string"
+				}
 			}
 
 			if prefix == typeDefPrefix {


### PR DESCRIPTION
### Description

errors will happen when there are `[]byte` in msg struct.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* replace apiType `uint8[]` with `string`