### PR TITLE
fix: changed validator jail timestamp to grpc compliant unit

### DIFF
--- a/x/slashing/keeper/msg_server.go
+++ b/x/slashing/keeper/msg_server.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"math"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -81,7 +80,7 @@ func (k msgServer) Impeach(goCtx context.Context, msg *types.MsgImpeach) (*types
 	}
 
 	// Jail forever.
-	k.JailUntil(ctx, consAddr, time.Unix(math.MaxInt64, 0))
+	k.JailUntil(ctx, consAddr, time.Unix(253402300800, 0))
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(


### PR DESCRIPTION
### Description

Changed validator jail timestamp from max.Int64 to GRPC max timestamp

### Rationale

max.Int64 causes error when used with GRPC since it exceeds the max possible timestamp

### Example

-

### Changes

Changed jail timestamp in slashing/msg_server.go  