### PR TITLE
fix: fix impeach validator

### DIFF
--- a/x/slashing/keeper/msg_server.go
+++ b/x/slashing/keeper/msg_server.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -80,7 +79,7 @@ func (k msgServer) Impeach(goCtx context.Context, msg *types.MsgImpeach) (*types
 	}
 
 	// Jail forever.
-	k.JailUntil(ctx, consAddr, time.Unix(253402300800, 0))
+	k.JailForever(ctx, consAddr)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(

--- a/x/slashing/keeper/signing_info.go
+++ b/x/slashing/keeper/signing_info.go
@@ -113,6 +113,29 @@ func (k Keeper) JailUntil(ctx sdk.Context, consAddr sdk.ConsAddress, jailTime ti
 	k.SetValidatorSigningInfo(ctx, consAddr, signInfo)
 }
 
+// JailForever attempts to set the validator's JailedUntil attribute in its signing
+// info to a very big value. When no signing info found, it will create a new signing
+// info for the validator.
+func (k Keeper) JailForever(ctx sdk.Context, consAddr sdk.ConsAddress) {
+	signingInfo, found := k.GetValidatorSigningInfo(ctx, consAddr)
+	if !found {
+		// Allow jail forever a no signing info validator.
+		signingInfo = types.NewValidatorSigningInfo(
+			consAddr,
+			ctx.BlockHeight(),
+			0,
+			time.Unix(0, 0),
+			false,
+			0,
+		)
+	}
+
+	// Jail to 10000-1-1 08:00:00.
+	signingInfo.JailedUntil = time.Unix(253402300800, 0)
+
+	k.SetValidatorSigningInfo(ctx, consAddr, signingInfo)
+}
+
 // Tombstone attempts to tombstone a validator. It will panic if signing info for
 // the given validator does not exist.
 func (k Keeper) Tombstone(ctx sdk.Context, consAddr sdk.ConsAddress) {


### PR DESCRIPTION
### Description

When no signing info is found for a validator, we should create a new signing info for the validator, and then we can jail this validator forever.

### Rationale

To avoid panic when impeaching a no-signing info validator.

### Example

NA

### Changes

Notable changes:
* NA