### PR TITLE
fix: fix jail until time for impeaching validator

### DIFF
--- a/x/slashing/keeper/signing_info.go
+++ b/x/slashing/keeper/signing_info.go
@@ -130,8 +130,8 @@ func (k Keeper) JailForever(ctx sdk.Context, consAddr sdk.ConsAddress) {
 		)
 	}
 
-	// Jail to 10000-1-1 08:00:00.
-	signingInfo.JailedUntil = time.Unix(253402300800, 0)
+	// Jail to 10000-1-1 07:59:59.
+	signingInfo.JailedUntil = time.Unix(253402300799, 0)
 
 	k.SetValidatorSigningInfo(ctx, consAddr, signingInfo)
 }

--- a/x/slashing/keeper/signing_info_test.go
+++ b/x/slashing/keeper/signing_info_test.go
@@ -94,3 +94,15 @@ func TestJailUntil(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, time.Unix(253402300799, 0).UTC(), info.JailedUntil)
 }
+
+func TestJailForever(t *testing.T) {
+	app := simapp.Setup(t, false, true)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	addrDels := simapp.AddTestAddrsIncremental(app, ctx, 1, app.StakingKeeper.TokensFromConsensusPower(ctx, 200))
+
+	app.SlashingKeeper.JailForever(ctx, sdk.ConsAddress(addrDels[0]))
+
+	info, ok := app.SlashingKeeper.GetValidatorSigningInfo(ctx, sdk.ConsAddress(addrDels[0]))
+	require.True(t, ok)
+	require.Equal(t, time.Unix(253402300799, 0).UTC(), info.JailedUntil)
+}


### PR DESCRIPTION
### Description

The longest time supported should be 253402300799, if one second more, it can't be unmarshaled.

### Rationale

Fix the panic problem when impeaching a validator.

### Example

TestJailForever

### Changes

Notable changes:
* change jail until time from 10000-01-01 08:00:00 to 10000-01-01 07:59:59