### PR TITLE
feat: change default power reduction from 1e6 to 1e18

### DIFF
--- a/types/staking.go
+++ b/types/staking.go
@@ -19,7 +19,7 @@ const (
 )
 
 // DefaultPowerReduction is the default amount of staking tokens required for 1 unit of consensus-engine power
-var DefaultPowerReduction = NewIntFromUint64(1000000)
+var DefaultPowerReduction = NewIntFromUint64(1e18)
 
 // TokensToConsensusPower - convert input tokens to potential consensus-engine power
 func TokensToConsensusPower(tokens Int, powerReduction Int) int64 {


### PR DESCRIPTION
### Description

Change the default power reduction from 1e6 to 1e18.

### Rationale

In Greenfield, we use BNB as our native token, we want to keep the same decimal with BNB on BSC.

### Example

NA

### Changes

Notable changes:
* change default power reduction