### PR TITLE
fix: initial setup for staking, slash and distribution

### DIFF
--- a/x/distribution/types/params.go
+++ b/x/distribution/types/params.go
@@ -25,7 +25,7 @@ func ParamKeyTable() paramtypes.KeyTable {
 // DefaultParams returns default distribution parameters
 func DefaultParams() Params {
 	return Params{
-		CommunityTax:        sdk.ZeroDec(),            // 0%
+		CommunityTax:        sdk.NewDecWithPrec(2, 2), // 2%
 		BaseProposerReward:  sdk.NewDecWithPrec(1, 2), // 1%
 		BonusProposerReward: sdk.NewDecWithPrec(4, 2), // 4%
 		WithdrawAddrEnabled: true,


### PR DESCRIPTION
### Description

Modify the default params of the staking, slash, and distribution module to adapt to Greenfield.

### Rationale

The original default params aren't suitable for Greenfield, so we need to modify them.

### Example

NA

### Changes

Notable changes:
* Modify some default params in the staking, slash, and distribution module.