### PR TITLE
fix: data race issue

### DIFF
--- a/x/auth/tx/eip712.go
+++ b/x/auth/tx/eip712.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 )
 
-var domain = apitypes.TypedDataDomain{
+var domain = &apitypes.TypedDataDomain{
 	Name:              "Greenfield Tx",
 	Version:           "1.0.0",
 	VerifyingContract: "greenfield",
@@ -180,11 +180,7 @@ func WrapTxToTypedData(
 	// filling nil value
 	cleanTypesAndMsgValue(msgTypes, "Msg", txData["msg"].(map[string]interface{}))
 
-	var domainTemp apitypes.TypedDataDomain
-	domainTemp.Name = domain.Name
-	domainTemp.Version = domain.Version
-	domainTemp.VerifyingContract = domain.VerifyingContract
-	domainTemp.Salt = domain.Salt
+	domainTemp := *domain
 	domainTemp.ChainId = math.NewHexOrDecimal256(int64(chainID))
 	typedData := apitypes.TypedData{
 		Types:       msgTypes,


### PR DESCRIPTION
### Description

This pr aims to fix data race issue within EIP712 sign mode's `GetSignBytes` method

### Rationale

The previous implementation is not thread-safe.

### Changes

- The EIP712 domain will be created locally.
<img width="468" alt="image" src="https://user-images.githubusercontent.com/48975233/225523932-d1951528-3e61-4dff-9ef7-e63d3e623434.png">

- Remove global `MsgCodec`
