### PR TITLE
fix: revert KeyUpgradedClient key in upgrade module

### DIFF
--- a/x/upgrade/types/keys.go
+++ b/x/upgrade/types/keys.go
@@ -28,6 +28,10 @@ const (
 
 	// KeyUpgradedConsState is the sub-key under which upgraded consensus state will be stored
 	KeyUpgradedConsState = "upgradedConsState"
+
+	// KeyUpgradedClient is the sub-key under which upgraded client state will be stored
+	// it's unused, but need to compatible to ibc-go package
+	KeyUpgradedClient = "upgradedClient"
 )
 
 // UpgradedConsStateKey is the key under which the upgraded consensus state is saved


### PR DESCRIPTION
### Description

Greenfield relies on the ibc-go package, but ibc-go needs to refer to the KeyUpgradedClient of cosmos-sdk.

Add it back for code compatibility.

### Rationale

<img width="1696" alt="image" src="https://user-images.githubusercontent.com/25412254/227493438-560518c7-3393-4609-9bf0-2cce76804c8f.png">


### Example

N/A

### Changes

Notable changes:
* upgrae/type