### PR TITLE
fix: add rlp support for int type

### DIFF
--- a/bsc/rlp/decode.go
+++ b/bsc/rlp/decode.go
@@ -153,6 +153,8 @@ func makeDecoder(typ reflect.Type, tags tags) (dec decoder, err error) {
 		return decodeDecoder, nil
 	case isUint(kind):
 		return decodeUint, nil
+	case isInt(kind):
+		return decodeInt, nil
 	case kind == reflect.Bool:
 		return decodeBool, nil
 	case kind == reflect.String:
@@ -184,6 +186,16 @@ func decodeUint(s *Stream, val reflect.Value) error {
 		return wrapStreamError(err, val.Type())
 	}
 	val.SetUint(num)
+	return nil
+}
+
+func decodeInt(s *Stream, val reflect.Value) error {
+	typ := val.Type()
+	num, err := s.uint(typ.Bits())
+	if err != nil {
+		return wrapStreamError(err, val.Type())
+	}
+	val.SetInt(int64(num))
 	return nil
 }
 

--- a/bsc/rlp/encode.go
+++ b/bsc/rlp/encode.go
@@ -330,6 +330,8 @@ func makeWriter(typ reflect.Type, ts tags) (writer, error) {
 		return makeEncoderWriter(typ), nil
 	case isUint(kind):
 		return writeUint, nil
+	case isInt(kind):
+		return writeInt, nil
 	case kind == reflect.Bool:
 		return writeBool, nil
 	case kind == reflect.String:
@@ -372,6 +374,14 @@ func writeUint(val reflect.Value, w *encbuf) error {
 		w.str = append(w.str, w.sizebuf[:s+1]...)
 	}
 	return nil
+}
+
+func writeInt(val reflect.Value, w *encbuf) error {
+	i := val.Int()
+	if i < 0 {
+		return fmt.Errorf("rlp: cannot encode negative integer %d", i)
+	}
+	return writeUint(reflect.ValueOf(uint64(i)), w)
 }
 
 func writeBool(val reflect.Value, w *encbuf) error {

--- a/bsc/rlp/typecache.go
+++ b/bsc/rlp/typecache.go
@@ -210,6 +210,10 @@ func isUint(k reflect.Kind) bool {
 	return k >= reflect.Uint && k <= reflect.Uintptr
 }
 
+func isInt(k reflect.Kind) bool {
+	return k >= reflect.Int && k < reflect.Uint
+}
+
 func isByteArray(typ reflect.Type) bool {
 	return (typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array) && isByte(typ.Elem())
 }


### PR DESCRIPTION
### Description

This pr aims to add rlp support for int type.

### Rational

For a non-negative int variable, rlp encode/decode support is necessary.

### Changes

Notable changes:
* add rlp support for int type