### PR TITLE
feat: add 'bls' key-type to keyring management

### DIFF
--- a/client/keys/output.go
+++ b/client/keys/output.go
@@ -1,6 +1,8 @@
 package keys
 
 import (
+	"encoding/hex"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -13,11 +15,12 @@ import (
 // KeyOutput defines a structure wrapping around an Info object used for output
 // functionality.
 type KeyOutput struct {
-	Name     string `json:"name" yaml:"name"`
-	Type     string `json:"type" yaml:"type"`
-	Address  string `json:"address" yaml:"address"`
-	PubKey   string `json:"pubkey" yaml:"pubkey"`
-	Mnemonic string `json:"mnemonic,omitempty" yaml:"mnemonic"`
+	Name      string `json:"name" yaml:"name"`
+	Type      string `json:"type" yaml:"type"`
+	Address   string `json:"address" yaml:"address"`
+	PubKey    string `json:"pubkey" yaml:"pubkey"`
+	PubKeyHex string `json:"pubkey_hex" yaml:"pubkey_hex"`
+	Mnemonic  string `json:"mnemonic,omitempty" yaml:"mnemonic"`
 }
 
 // NewKeyOutput creates a default KeyOutput instance without Mnemonic, Threshold and PubKeys
@@ -31,10 +34,11 @@ func NewKeyOutput(name string, keyType keyring.KeyType, a sdk.Address, pk crypto
 		return KeyOutput{}, err
 	}
 	return KeyOutput{
-		Name:    name,
-		Type:    keyType.String(),
-		Address: a.String(),
-		PubKey:  string(bz),
+		Name:      name,
+		Type:      keyType.String(),
+		Address:   a.String(),
+		PubKey:    string(bz),
+		PubKeyHex: hex.EncodeToString(pk.Bytes()),
 	}, nil
 }
 

--- a/client/keys/output_test.go
+++ b/client/keys/output_test.go
@@ -42,7 +42,7 @@ func TestBech32KeysOutput(t *testing.T) {
 	out, err := MkAccKeyOutput(k)
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, out)
-	require.Equal(t, "{Name:multisig Type:multi Address:0x9a4fF4eA75776B118b6d13B3aBD8737511CcdAE0 PubKey:{\"@type\":\"/cosmos.crypto.multisig.LegacyAminoPubKey\",\"threshold\":1,\"public_keys\":[{\"@type\":\"/cosmos.crypto.secp256k1.PubKey\",\"key\":\"AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ\"}]} Mnemonic:}", fmt.Sprintf("%+v", out))
+	require.Equal(t, "{Name:multisig Type:multi Address:0x9a4fF4eA75776B118b6d13B3aBD8737511CcdAE0 PubKey:{\"@type\":\"/cosmos.crypto.multisig.LegacyAminoPubKey\",\"threshold\":1,\"public_keys\":[{\"@type\":\"/cosmos.crypto.secp256k1.PubKey\",\"key\":\"AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ\"}]} PubKeyHex:22c1f7e208011226eb5ae9872102eaeba00ee3bdf3ddd4069d9a63af58cdab252c22a577d17fcc83ea92db0360c9 Mnemonic:}", fmt.Sprintf("%+v", out))
 }
 
 func TestProtoMarshalJSON(t *testing.T) {

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -218,8 +218,8 @@ func newKeystore(kr keyring.Keyring, cdc codec.Codec, backend string, opts ...Op
 	// Default options for keybase, these can be overwritten using the
 	// Option function
 	options := Options{
-		SupportedAlgos:       SigningAlgoList{hd.Secp256k1},
-		SupportedAlgosLedger: SigningAlgoList{hd.Secp256k1},
+		SupportedAlgos:       SigningAlgoList{hd.EthSecp256k1, hd.EthBLS, hd.Secp256k1},
+		SupportedAlgosLedger: SigningAlgoList{hd.EthSecp256k1, hd.EthBLS, hd.Secp256k1},
 	}
 
 	for _, optionFn := range opts {


### PR DESCRIPTION
### Description

add `bls` key-type to keyring management

### Rationale

support `bls` algorithm to help the validator manage the bls_keys in command lines.

### Example

1. add keys
cmd: `./build/simd keys add test --key-type eth_bls --home ./.local --keyring-backend test`
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/25412254/232417776-1057f7b5-8cd4-47a6-8625-844f54d3fadd.png">

2. show keys
cmd: `./build/simd keys list --home ./.local --keyring-backend test`
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/25412254/232417878-a7041c0c-0837-4efe-87f4-815e3d221b8f.png">

3. import keys
cmd: `./build/simd keys import test ./priv.key --home ./.local --keyring-backend test`
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/25412254/232418027-5bb4cae9-9ccb-46d1-b171-775d8fe27bc9.png">


### Changes

Notable changes:
* keyring tool