### PR TITLE
feat: add Bytes/SetBytes for Bigendian encoding for Uint

### DIFF
--- a/math/uint.go
+++ b/math/uint.go
@@ -199,6 +199,18 @@ func (u *Uint) Unmarshal(data []byte) error {
 	return UintOverflow(u.i)
 }
 
+// Bytes returns the value of x as a big-endian byte slice.
+func (u Uint) Bytes() []byte {
+	return u.i.Bytes()
+}
+
+// SetBytes interprets buf as the bytes of a big-endian unsigned
+// integer, sets z to that value, and returns z.
+func (u Uint) SetBytes(buf []byte) Uint {
+	u.i = u.i.SetBytes(buf)
+	return u
+}
+
 // Size implements the gogo proto custom type interface.
 func (u *Uint) Size() int {
 	bz, _ := u.Marshal()

--- a/math/uint_test.go
+++ b/math/uint_test.go
@@ -366,3 +366,14 @@ func TestWeakUnmarshalOverflow(t *testing.T) {
 		t.Fatalf("out of range value not reported, got instead %q", errStr)
 	}
 }
+
+func (s *uintTestSuite) TestUintBigEndian() {
+	u1 := sdkmath.NewUint(256)
+	u1b := u1.Bytes()
+
+	u2 := sdkmath.NewUint(0)
+	u2 = u2.SetBytes(u1b)
+
+	s.Require().Equal(u1, u2)
+
+}


### PR DESCRIPTION
### Description

This pr cherry picks https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/114:

+ add Bytes/SetBytes to get big endian format for Uint.

### Rationale

Cherry-pick the previous changes.

### Example

N/A

### Changes

Notable changes:
* add Bytes/SetBytes to get big endian format for Uint.
