### PR TITLE
fix: remove orm directory for buf

### DIFF
--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -6,4 +6,3 @@
 version: v1
 directories:
   - proto
-  - orm/internal


### PR DESCRIPTION
### Description

This pr will fix the issue when generating swagger file int greenfiled:

```
Failure: directory "orm/internal" listed in ../github.com/bnb-chain/greenfield-cosmos-sdk@v0.0.0-20230509083558-18999c4902bf/buf.work.yaml contains no .proto files
```

### Rationale

Fix error when generating swagger file.

### Example

N/A

### Changes

Notable changes:
* remove orm directory for buf
