### PR TITLE
feat: disable gov v1beta1

### DIFF
--- a/tests/e2e/feegrant/suite.go
+++ b/tests/e2e/feegrant/suite.go
@@ -822,7 +822,7 @@ func (s *E2ETestSuite) TestFilteredFeeAllowance() {
 	}
 	spendLimit := sdk.NewCoin("stake", sdk.NewInt(1000))
 
-	allowMsgs := strings.Join([]string{sdk.MsgTypeURL(&govv1beta1.MsgSubmitProposal{}), sdk.MsgTypeURL(&govv1.MsgVoteWeighted{})}, ",")
+	allowMsgs := strings.Join([]string{sdk.MsgTypeURL(&govv1.MsgSubmitProposal{}), sdk.MsgTypeURL(&govv1.MsgVoteWeighted{})}, ",")
 
 	testCases := []struct {
 		name         string

--- a/x/feegrant/client/cli/tx_test.go
+++ b/x/feegrant/client/cli/tx_test.go
@@ -608,7 +608,7 @@ func (s *CLITestSuite) TestFilteredFeeAllowance() {
 	}
 	spendLimit := sdk.NewCoin("stake", sdk.NewInt(1000))
 
-	allowMsgs := strings.Join([]string{sdk.MsgTypeURL(&govv1beta1.MsgSubmitProposal{}), sdk.MsgTypeURL(&govv1.MsgVoteWeighted{})}, ",")
+	allowMsgs := strings.Join([]string{sdk.MsgTypeURL(&govv1.MsgSubmitProposal{}), sdk.MsgTypeURL(&govv1.MsgVoteWeighted{})}, ",")
 
 	testCases := []struct {
 		name         string

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"strconv"
 	"strings"
 
@@ -200,10 +201,12 @@ $ %s tx gov submit-legacy-proposal --title="Test Proposal" --description="My awe
 				return fmt.Errorf("failed to create proposal content: unknown proposal type %s", proposal.Type)
 			}
 
-			msg, err := v1beta1.NewMsgSubmitProposal(content, amount, clientCtx.GetFromAddress())
+			govAcctAddress := authtypes.NewModuleAddress(types.ModuleName).String()
+			contentMsg, err := v1.NewLegacyContent(content, govAcctAddress)
 			if err != nil {
 				return fmt.Errorf("invalid message: %w", err)
 			}
+			msg, err := v1.NewMsgSubmitProposal([]sdk.Msg{contentMsg}, amount, clientCtx.GetFromAddress().String(), "", proposal.Title, proposal.Description)
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -276,11 +276,7 @@ func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	msgServer := keeper.NewMsgServerImpl(am.keeper)
-	v1beta1.RegisterMsgServer(cfg.MsgServer(), keeper.NewLegacyMsgServerImpl(am.accountKeeper.GetModuleAddress(govtypes.ModuleName).String(), msgServer))
 	v1.RegisterMsgServer(cfg.MsgServer(), msgServer)
-
-	legacyQueryServer := keeper.NewLegacyQueryServer(am.keeper)
-	v1beta1.RegisterQueryServer(cfg.QueryServer(), legacyQueryServer)
 	v1.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	m := keeper.NewMigrator(am.keeper, am.legacySubspace)

--- a/x/params/client/cli/tx.go
+++ b/x/params/client/cli/tx.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"fmt"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -10,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
-	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	paramscutils "github.com/cosmos/cosmos-sdk/x/params/client/utils"
 	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 )
@@ -76,10 +78,12 @@ Where proposal.json contains:
 				return err
 			}
 
-			msg, err := govv1beta1.NewMsgSubmitProposal(content, deposit, from)
+			govAcctAddress := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+			contentMsg, err := govv1.NewLegacyContent(content, govAcctAddress)
 			if err != nil {
 				return err
 			}
+			msg, err := govv1.NewMsgSubmitProposal([]sdk.Msg{contentMsg}, deposit, from.String(), "", content.Title, content.Description)
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},


### PR DESCRIPTION
### Description

gov v1beta1 server should be disabled, migrate such change to v47.2. 

### Rationale

would cause user's confusion providing the legacy server

### Example

NA

### Changes

Notable changes:
* NA