### PR TITLE
release: draft release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v0.2.0
+This release upgrades cosmos-sdk to v0.47.2.  
+
 ## v0.1.1
 This is a maintenance release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 ## v0.2.0
-This release upgrades cosmos-sdk to v0.47.2.  
+This release upgrades the reference cosmos-sdk to v0.47.2. As the cosmos-sdk v0.47.2 is a huge breaking upgrade, 
+we decide to cherry-pick the recent contributed commits and apply to the v0.47.2. The commit history previous 
+releases are archived and the branch is backed up in the `master_back` branch.
+
+Notable breaking changes:
+1. The previous keyring is replaced by the new keyring. Please regenerate them, otherwise you will get error.
+
+Other notable changes, please refer to the [changelogs of cosmos-sdk v0.47.1](https://github.com/cosmos/cosmos-sdk/blob/v0.47.1/CHANGELOG.md)
+and [changelogs of cosmos-sdk v0.47.2](https://github.com/cosmos/cosmos-sdk/blob/v0.47.2/CHANGELOG.md).
 
 ## v0.1.1
 This is a maintenance release.


### PR DESCRIPTION
### Description

This release upgrades cosmos-sdk to v0.47.2.  

### Rationale
This release upgrades the reference cosmos-sdk to v0.47.2. As the cosmos-sdk v0.47.2 is a huge breaking upgrade, 
we decide to cherry-pick the recent contributed commits and apply to the v0.47.2. The commit history previous 
releases are archived and the branch is backed up in the `master_back` branch.

### Example

Please find detailed information in the PR

### Changes


Notable breaking changes:
1. The previous keyring is replaced by the new keyring. Please regenerate them, otherwise you will get error.

Other notable changes, please refer to the [changelogs of cosmos-sdk v0.47.2](https://github.com/cosmos/cosmos-sdk/blob/v0.47.1/CHANGELOG.md).