### PR TITLE
feat: update the calculation logic of BLS signature threshold

### DIFF
--- a/types/cross_chain.go
+++ b/types/cross_chain.go
@@ -138,3 +138,10 @@ func DecodePackageHeader(packageHeader []byte) (PackageHeader, error) {
 
 	return header, nil
 }
+
+func CeilDiv(x, y int) int {
+	if y == 0 {
+		return 0
+	}
+	return (x + y - 1) / y
+}

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -161,8 +161,8 @@ func (k Keeper) CheckClaim(ctx sdk.Context, claim *types.MsgClaim) (sdk.AccAddre
 	}
 
 	// The valid voted validators should be no less than 2/3 validators.
-	if len(votedPubKeys) <= len(validators)*2/3 {
-		return sdk.AccAddress{}, nil, sdkerrors.Wrapf(types.ErrBlsVotesNotEnough, "not enough validators voted, need: %d, voted: %d", len(validators)*2/3, len(votedPubKeys))
+	if len(votedPubKeys) < sdk.CeilDiv(len(validators)*2, 3) {
+		return sdk.AccAddress{}, nil, sdkerrors.Wrapf(types.ErrBlsVotesNotEnough, "not enough validators voted, need: %d, voted: %d", sdk.CeilDiv(len(validators)*2, 3), len(votedPubKeys))
 	}
 
 	// Verify the aggregated signature.

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -139,7 +139,6 @@ func (s *TestSuite) TestProcessClaim() {
 	// wrong validator set
 	wrongValBitSet = bitset.New(256)
 	wrongValBitSet.Set(uint(validatorMap[newValidators[0].RelayerAddress]))
-	wrongValBitSet.Set(uint(validatorMap[newValidators[1].RelayerAddress]))
 	msgClaim.VoteAddressSet = wrongValBitSet.Bytes()
 	s.ctx = s.ctx.WithBlockTime(time.Unix(int64(msgClaim.Timestamp), 0))
 	_, _, err = s.oracleKeeper.CheckClaim(s.ctx, &msgClaim)


### PR DESCRIPTION
### Description

This pr will update the calculation logic of BLS signature threshold. 

Before we just use `len(validators)*2/3` to get the BLS signature threshold. This pr will change the calculation logic of the threshold:

```go
func CeilDiv(x, y int) int {
	if y == 0 {
		return 0
	}
	return (x + y - 1) / y
}
```

For example, there are total 3 validators. 

Before, the threshold of valid signed validator count is `3`. If we change the calculation logic, the threshold is `2`.

### Rationale

To change the calculation logic of BLS signature threshold to be consistent with BSC.

### Example

n/a

### Changes

Notable changes:
* update the calculation logic of BLS signature threshold
