### PR TITLE
fix: missing copy of transient store

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -581,22 +581,20 @@ func (rs *Store) DeepCopyAndCache() types.CacheMultiStore {
 func (rs *Store) DeepCopy() *Store {
 	stores := make(map[types.StoreKey]types.CommitKVStore)
 	for k, v := range rs.stores {
-		var storeCache *cache.CommitKVStoreCache
 		if store, ok := v.(*cache.CommitKVStoreCache); ok {
 			if iavlStore, ok := store.CommitKVStore.(*iavl.Store); ok {
 				tree := iavlStore.CloneMutableTree()
 				if tree != nil {
-					storeCache = cache.NewCommitKVStoreCache(iavl.UnsafeNewStore(tree), 1000)
+					stores[k] = cache.NewCommitKVStoreCache(iavl.UnsafeNewStore(tree), 1000).CommitKVStore
 				}
 			}
 		} else if store, ok := v.(*iavl.Store); ok {
 			tree := store.CloneMutableTree()
 			if tree != nil {
-				storeCache = cache.NewCommitKVStoreCache(iavl.UnsafeNewStore(tree), 1000)
+				stores[k] = cache.NewCommitKVStoreCache(iavl.UnsafeNewStore(tree), 1000).CommitKVStore
 			}
-		}
-		if storeCache != nil {
-			stores[k] = storeCache.CommitKVStore
+		} else if _, ok := v.(*transient.Store); ok {
+			stores[k] = transient.NewStore()
 		}
 	}
 


### PR DESCRIPTION
### Description

This pr is to fix errors in `DeepCopy` and `DeepCopyAndCache` methods.

### Changes

Notable changes:
* add missing copy of transient store