### PR TITLE
chore: implement base64 encoding in EIP712

### DIFF
--- a/x/auth/tx/eip712.go
+++ b/x/auth/tx/eip712.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -475,7 +476,8 @@ func cleanTypesAndMsgValue(typedData apitypes.Types, primaryType string, msgValu
 				newValue := make(map[string]interface{})
 				bz, _ := json.Marshal(anyValue)
 				newValue["type"] = anyValue["@type"]
-				newValue["value"] = bz
+				base64Str := base64.StdEncoding.EncodeToString(bz) // base64 encode to keep consistency with js-sdk
+				newValue["value"] = []byte(base64Str)
 				msgValue[encName[:len(encName)-3]] = newValue
 				typedData[primaryType][i].Name = encName[:len(encName)-3]
 				typedData[primaryType][i].Type = "TypeAny"


### PR DESCRIPTION
### Description

This pr is to implement base64 encoding in EIP712

### Rationale

To keep consistency with js-sdk, we should adopt base64 encoding in EIP712.

### Changes

Notable changes:
* implement base64 encoding in EIP712