### PR TITLE
fix: limit pagination to protect the node would not be Query DoS

### DIFF
--- a/types/query/pagination.go
+++ b/types/query/pagination.go
@@ -38,9 +38,7 @@ func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
 
 	if limit < 0 {
 		return 1, 0, status.Error(codes.InvalidArgument, "limit must greater than 0")
-	} else if limit == 0 {
-		limit = DefaultLimit
-	} else if limit > DefaultLimit {
+	} else if limit > DefaultLimit || limit == 0 {
 		// limit to protect the node would not be Query DoS
 		limit = DefaultLimit
 	}

--- a/types/query/pagination.go
+++ b/types/query/pagination.go
@@ -40,6 +40,9 @@ func ParsePagination(pageReq *PageRequest) (page, limit int, err error) {
 		return 1, 0, status.Error(codes.InvalidArgument, "limit must greater than 0")
 	} else if limit == 0 {
 		limit = DefaultLimit
+	} else if limit > DefaultLimit {
+		// limit to protect the node would not be Query DoS
+		limit = DefaultLimit
 	}
 
 	page = offset/limit + 1
@@ -74,6 +77,9 @@ func Paginate(
 
 		// count total results when the limit is zero/not supplied
 		countTotal = true
+	} else if limit > DefaultLimit {
+		// limit to protect the node would not be Query DoS
+		limit = DefaultLimit
 	}
 
 	if len(key) != 0 {

--- a/types/query/pagination_test.go
+++ b/types/query/pagination_test.go
@@ -234,11 +234,20 @@ func (s *paginationTestSuite) TestReversePagination() {
 	s.Require().NotNil(res1.Pagination.NextKey)
 
 	s.T().Log("verify paginate with custom limit and countTotal, Reverse false")
-	pageReq = &query.PageRequest{Limit: 150}
+	pageReq = &query.PageRequest{Limit: 100}
 	request = types.NewQueryAllBalancesRequest(addr1, pageReq)
 	res1, err = queryClient.AllBalances(gocontext.Background(), request)
 	s.Require().NoError(err)
-	s.Require().Equal(res1.Balances.Len(), 150)
+	s.Require().Equal(res1.Balances.Len(), 100)
+	s.Require().NotNil(res1.Pagination.NextKey)
+	s.Require().Equal(res1.Pagination.Total, uint64(0))
+
+	s.T().Log("verify paginate with custom limit and countTotal, Reverse false")
+	pageReq = &query.PageRequest{Limit: 50, Offset: 100}
+	request = types.NewQueryAllBalancesRequest(addr1, pageReq)
+	res1, err = queryClient.AllBalances(gocontext.Background(), request)
+	s.Require().NoError(err)
+	s.Require().Equal(res1.Balances.Len(), 50)
 	s.Require().NotNil(res1.Pagination.NextKey)
 	s.Require().Equal(res1.Pagination.Total, uint64(0))
 


### PR DESCRIPTION
### Description

 limit pagination to protect the node would not be Query DoS

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...