### PR TITLE
feat: add option for disabling event emit

### DIFF
--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -24,6 +24,11 @@ func SetPruning(opts pruningtypes.PruningOptions) func(*BaseApp) {
 	return func(bapp *BaseApp) { bapp.cms.SetPruning(opts) }
 }
 
+// SetEventing sets an eventing option on the event manager with the app
+func SetEventing(eventingStr string) func(*BaseApp) {
+	return func(bapp *BaseApp) { sdk.SetEventingOption(eventingStr) }
+}
+
 // SetMinGasPrices returns an option that sets the minimum gas prices on the app.
 func SetMinGasPrices(gasPricesStr string) func(*BaseApp) {
 	gasPrices, err := sdk.ParseDecCoins(gasPricesStr)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -272,7 +272,7 @@ func DefaultConfig() *Config {
 			Pruning:             pruningtypes.PruningOptionDefault,
 			PruningKeepRecent:   "0",
 			PruningInterval:     "0",
-			Eventing:            sdk.EventingOptionNothing,
+			Eventing:            sdk.EventingOptionEverything,
 			MinRetainBlocks:     0,
 			IndexEvents:         make([]string, 0),
 			IAVLCacheSize:       781250,

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -48,6 +48,8 @@ type BaseConfig struct {
 	PruningKeepRecent string `mapstructure:"pruning-keep-recent"`
 	PruningInterval   string `mapstructure:"pruning-interval"`
 
+	Eventing string `mapstructure:"eventing"`
+
 	// HaltHeight contains a non-zero block height at which a node will gracefully
 	// halt and shutdown that can be used to assist upgrades and testing.
 	//
@@ -270,6 +272,7 @@ func DefaultConfig() *Config {
 			Pruning:             pruningtypes.PruningOptionDefault,
 			PruningKeepRecent:   "0",
 			PruningInterval:     "0",
+			Eventing:            sdk.EventingOptionNothing,
 			MinRetainBlocks:     0,
 			IndexEvents:         make([]string, 0),
 			IAVLCacheSize:       781250,

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -27,13 +27,13 @@ minimum-gas-prices = "{{ .BaseConfig.MinGasPrices }}"
 # custom: allow pruning options to be manually specified through 'pruning-keep-recent', and 'pruning-interval'
 pruning = "{{ .BaseConfig.Pruning }}"
 
-# everything: all events will be emitted
-# nothing: no events will be emitted.
-eventing = "{{ .BaseConfig.Eventing }}"
-
 # These are applied if and only if the pruning strategy is custom.
 pruning-keep-recent = "{{ .BaseConfig.PruningKeepRecent }}"
 pruning-interval = "{{ .BaseConfig.PruningInterval }}"
+
+# everything: all events will be emitted
+# nothing: no events will be emitted.
+eventing = "{{ .BaseConfig.Eventing }}"
 
 # HaltHeight contains a non-zero block height at which a node will gracefully
 # halt and shutdown that can be used to assist upgrades and testing.

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -27,6 +27,10 @@ minimum-gas-prices = "{{ .BaseConfig.MinGasPrices }}"
 # custom: allow pruning options to be manually specified through 'pruning-keep-recent', and 'pruning-interval'
 pruning = "{{ .BaseConfig.Pruning }}"
 
+# everything: all events will be emitted
+# nothing: no events will be emitted.
+eventing = "{{ .BaseConfig.Eventing }}"
+
 # These are applied if and only if the pruning strategy is custom.
 pruning-keep-recent = "{{ .BaseConfig.PruningKeepRecent }}"
 pruning-interval = "{{ .BaseConfig.PruningInterval }}"

--- a/server/start.go
+++ b/server/start.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/types"
 	pruningtypes "github.com/cosmos/cosmos-sdk/store/pruning/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/mempool"
 )
 
@@ -52,6 +53,7 @@ const (
 	FlagPruning             = "pruning"
 	FlagPruningKeepRecent   = "pruning-keep-recent"
 	FlagPruningInterval     = "pruning-interval"
+	FlagEventing            = "eventing"
 	FlagIndexEvents         = "index-events"
 	FlagMinRetainBlocks     = "min-retain-blocks"
 	FlagIAVLCacheSize       = "iavl-cache-size"
@@ -183,6 +185,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint64(FlagPruningInterval, 0, "Height interval at which pruned heights are removed from disk (ignored if pruning is not 'custom')")
 	cmd.Flags().Uint(FlagInvCheckPeriod, 0, "Assert registered invariants every N blocks")
 	cmd.Flags().Uint64(FlagMinRetainBlocks, 0, "Minimum block height offset during ABCI commit to prune Tendermint blocks")
+	cmd.Flags().String(FlagEventing, sdk.EventingOptionEverything, "Eventing strategy (everything|nothing)")
 
 	cmd.Flags().Bool(FlagAPIEnable, false, "Define if the API server should be enabled")
 	cmd.Flags().Bool(FlagAPISwagger, false, "Define if swagger documentation should automatically be registered (Note: the API must also be enabled)")

--- a/server/util.go
+++ b/server/util.go
@@ -480,6 +480,7 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 
 	return []func(*baseapp.BaseApp){
 		baseapp.SetPruning(pruningOpts),
+		baseapp.SetEventing(cast.ToString(appOpts.Get(FlagEventing))),
 		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(FlagMinGasPrices))),
 		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(FlagHaltHeight))),
 		baseapp.SetHaltTime(cast.ToUint64(appOpts.Get(FlagHaltTime))),

--- a/types/events.go
+++ b/types/events.go
@@ -34,11 +34,14 @@ const (
 var strategy emittingStrategy
 
 func SetEventingOption(option string) {
-	if option == "" || option == EventingOptionEverything {
+	switch option {
+	case "":
 		strategy = emittingEverything
-	} else if option == EventingOptionNothing {
+	case EventingOptionEverything:
+		strategy = emittingEverything
+	case EventingOptionNothing:
 		strategy = emittingNothing
-	} else {
+	default:
 		panic("invalid eventing option")
 	}
 }

--- a/types/events.go
+++ b/types/events.go
@@ -16,6 +16,33 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 
+// EventingOptionEverything will allow to emit all events.
+const EventingOptionEverything = "everything"
+
+// EventingOptionNothing will emit none events.
+const EventingOptionNothing = "nothing"
+
+type emittingStrategy int
+
+const (
+	// emittingEverything strategy will emit everything.
+	emittingEverything emittingStrategy = iota
+	// emittingNothing strategy will emit nothing.
+	emittingNothing
+)
+
+var strategy emittingStrategy
+
+func SetEventingOption(option string) {
+	if option == "" || option == EventingOptionEverything {
+		strategy = emittingEverything
+	} else if option == EventingOptionNothing {
+		strategy = emittingNothing
+	} else {
+		panic("invalid eventing option")
+	}
+}
+
 // ----------------------------------------------------------------------------
 // Event Manager
 // ----------------------------------------------------------------------------
@@ -35,12 +62,18 @@ func (em *EventManager) Events() Events { return em.events }
 // EmitEvent stores a single Event object.
 // Deprecated: Use EmitTypedEvent
 func (em *EventManager) EmitEvent(event Event) {
+	if strategy == emittingNothing {
+		return
+	}
 	em.events = em.events.AppendEvent(event)
 }
 
 // EmitEvents stores a series of Event objects.
 // Deprecated: Use EmitTypedEvents
 func (em *EventManager) EmitEvents(events Events) {
+	if strategy == emittingNothing {
+		return
+	}
 	em.events = em.events.AppendEvents(events)
 }
 
@@ -51,6 +84,9 @@ func (em EventManager) ABCIEvents() []abci.Event {
 
 // EmitTypedEvent takes typed event and emits converting it into Event
 func (em *EventManager) EmitTypedEvent(tev proto.Message) error {
+	if strategy == emittingNothing {
+		return nil
+	}
 	event, err := TypedEventToEvent(tev)
 	if err != nil {
 		return err
@@ -62,6 +98,9 @@ func (em *EventManager) EmitTypedEvent(tev proto.Message) error {
 
 // EmitTypedEvents takes series of typed events and emit
 func (em *EventManager) EmitTypedEvents(tevs ...proto.Message) error {
+	if strategy == emittingNothing {
+		return nil
+	}
 	events := make(Events, len(tevs))
 	for i, tev := range tevs {
 		res, err := TypedEventToEvent(tev)


### PR DESCRIPTION
### Description

This pr will allow node runners to define whether the node will emit events or not.
It is useful for nodes which do not want to emit any events.

### Rationale

new feat

### Example

```
Eventing = "everything"
Eventing = "nothing"
```

### Changes

Notable changes:
* new option in app.toml