### PR TITLE
fix: allow validator delegator from Genesis to be other addresses

### DIFF
--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -33,7 +33,7 @@ func GenTxCmd(mbm module.BasicManager, txEncCfg client.TxEncodingConfig, genBalI
 	fsCreateValidator, defaultsDesc := cli.CreateValidatorMsgFlagSet(ipDefault)
 
 	cmd := &cobra.Command{
-		Use:   "gentx [key_name] [amount] [validator] [relayer] [challenger] [blskey] [blsProof]",
+		Use:   "gentx [key_name] [amount] [delegator] [relayer] [challenger] [blskey] [blsProof]",
 		Short: "Generate a genesis tx carrying a self delegation",
 		Args:  cobra.ExactArgs(7),
 		Long: fmt.Sprintf(`Generate a genesis transaction that creates a validator with a self-delegation,
@@ -128,7 +128,11 @@ $ %s gentx my-key-name 1000000stake \
 			if err != nil {
 				return err
 			}
-			err = genutil.ValidateAccountInGenesis(genesisState, genBalIterator, addr, coins, cdc)
+			delegator, err := sdk.AccAddressFromHexUnsafe(args[2])
+			if err != nil {
+				return err
+			}
+			err = genutil.ValidateAccountInGenesis(genesisState, genBalIterator, delegator, coins, cdc)
 			if err != nil {
 				return errors.Wrap(err, "failed to validate account in genesis")
 			}
@@ -157,10 +161,6 @@ $ %s gentx my-key-name 1000000stake \
 			// ref: https://github.com/cosmos/cosmos-sdk/issues/8177
 			createValCfg.Amount = amount
 
-			validator, err := sdk.AccAddressFromHexUnsafe(args[2])
-			if err != nil {
-				return err
-			}
 			relayer, err := sdk.AccAddressFromHexUnsafe(args[3])
 			if err != nil {
 				return err
@@ -178,8 +178,8 @@ $ %s gentx my-key-name 1000000stake \
 				return fmt.Errorf("invalid bls proof, len: %d", len(blsProof))
 			}
 
-			createValCfg.Validator = validator
-			createValCfg.Delegator = addr
+			createValCfg.Validator = addr
+			createValCfg.Delegator = delegator
 			createValCfg.Relayer = relayer
 			createValCfg.Challenger = challenger
 			createValCfg.BlsKey = blsPk

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -48,12 +48,13 @@ func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateVa
 		return nil, err
 	}
 
-	// For genesis block, the signer should be the self delegator itself,
-	// for other blocks, the signer should be the gov module account.
+	// For genesis block, the signer can be the validator address itself,
+	// because the delegator address is more privately key that may not be held by the deployer.
+	// For other blocks, the signer should be the gov module account.
 	govModuleAddr := k.authKeeper.GetModuleAddress(govtypes.ModuleName)
 	if ctx.BlockHeight() == 0 {
 		signers := msg.GetSigners()
-		if len(signers) != 1 || !signers[0].Equals(delAddr) {
+		if len(signers) != 1 || !signers[0].Equals(valAddr) {
 			return nil, types.ErrInvalidSigner
 		}
 	} else {


### PR DESCRIPTION
### Description

allow validator delegator from Genesis to be other addresses

### Rationale

the delegator address is more privately key that may not be held by the deployer.


### Example

add an example CLI or API response...

### Changes

Notable changes:
* staking