### PR TITLE
feat: skip sig verification on genesis block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ include contrib/devtools/Makefile
 ###############################################################################
 
 BUILD_TARGETS := build install
-
+.PHONY: build build-linux-amd64 build-linux-arm64
 build: BUILD_ARGS=-o $(BUILDDIR)/
 
 build-linux-amd64:

--- a/tests/e2e/genutil/suite.go
+++ b/tests/e2e/genutil/suite.go
@@ -67,8 +67,8 @@ func (s *E2ETestSuite) TestGenTxCmd() {
 			args: []string{
 				fmt.Sprintf("--%s=%s", flags.FlagChainID, s.network.Config.ChainID),
 				fmt.Sprintf("--%s=1", stakingcli.FlagCommissionRate),
-				val.Moniker,
 				amount.String(),
+				val.Address.String(),
 				val.Address.String(),
 				val.Address.String(),
 				val.Address.String(),
@@ -80,8 +80,8 @@ func (s *E2ETestSuite) TestGenTxCmd() {
 			name: "valid gentx",
 			args: []string{
 				fmt.Sprintf("--%s=%s", flags.FlagChainID, s.network.Config.ChainID),
-				val.Moniker,
 				amount.String(),
+				val.Address.String(),
 				val.Address.String(),
 				val.Address.String(),
 				val.Address.String(),
@@ -95,8 +95,8 @@ func (s *E2ETestSuite) TestGenTxCmd() {
 			args: []string{
 				fmt.Sprintf("--%s=%s", flags.FlagChainID, s.network.Config.ChainID),
 				fmt.Sprintf("--%s={\"key\":\"BOIkjkFruMpfOFC9oNPhiJGfmY2pHF/gwHdLDLnrnS0=\"}", stakingcli.FlagPubKey),
-				val.Moniker,
 				amount.String(),
+				val.Address.String(),
 				val.Address.String(),
 				val.Address.String(),
 				val.Address.String(),
@@ -110,8 +110,8 @@ func (s *E2ETestSuite) TestGenTxCmd() {
 			args: []string{
 				fmt.Sprintf("--%s=%s", flags.FlagChainID, s.network.Config.ChainID),
 				fmt.Sprintf("--%s={\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"BOIkjkFruMpfOFC9oNPhiJGfmY2pHF/gwHdLDLnrnS0=\"}", stakingcli.FlagPubKey),
-				val.Moniker,
 				amount.String(),
+				val.Address.String(),
 				val.Address.String(),
 				val.Address.String(),
 				val.Address.String(),

--- a/x/auth/ante/ante_test.go
+++ b/x/auth/ante/ante_test.go
@@ -351,8 +351,8 @@ func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 				}
 			},
 			false,
-			false,
-			sdkerrors.ErrUnauthorized,
+			true,
+			nil,
 		},
 		{
 			"new tx with another signer and incorrect account numbers",
@@ -371,8 +371,8 @@ func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 				}
 			},
 			false,
-			false,
-			sdkerrors.ErrUnauthorized,
+			true,
+			nil,
 		},
 		{
 			"new tx with another signer and correct account numbers",
@@ -398,6 +398,7 @@ func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Case %s", tc.desc), func(t *testing.T) {
+			t.Log(tc.desc)
 			suite := SetupTestSuite(t, false)
 			suite.ctx = suite.ctx.WithBlockHeight(0)
 			suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -153,6 +153,10 @@ func NewSigGasConsumeDecorator(ak AccountKeeper, sigGasConsumer SignatureVerific
 }
 
 func (sgcd SigGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	if ctx.BlockHeight() == 0 {
+		// skip the signature verification on the genesis block
+		return next(ctx, tx, simulate)
+	}
 	sigTx, ok := tx.(authsigning.SigVerifiableTx)
 	if !ok {
 		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -56,6 +56,11 @@ func NewSetPubKeyDecorator(ak AccountKeeper) SetPubKeyDecorator {
 }
 
 func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if ctx.BlockHeight() == 0 {
+		// skip the signature verification on the genesis block
+		return next(ctx, tx, simulate)
+	}
+
 	sigTx, ok := tx.(authsigning.SigVerifiableTx)
 	if !ok {
 		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
@@ -234,6 +239,10 @@ func OnlyLegacyAminoSigners(sigData signing.SignatureData) bool {
 }
 
 func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	if ctx.BlockHeight() == 0 {
+		// skip the signature verification on the genesis block
+		return next(ctx, tx, simulate)
+	}
 	sigTx, ok := tx.(authsigning.SigVerifiableTx)
 	if !ok {
 		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")

--- a/x/auth/tx/decoder.go
+++ b/x/auth/tx/decoder.go
@@ -168,3 +168,8 @@ func varintMinLength(n uint64) int {
 		return 10
 	}
 }
+
+// UnWrapTx returns the underlying Tx.
+func UnWrapTx(tx sdk.Tx) *tx.Tx {
+	return tx.(*wrapper).tx
+}


### PR DESCRIPTION
### Description

skip sig verification on genesis block

### Rationale

the `antehandler` will skip sig verification on the genesis block.

### Example

add an example CLI or API response...

### Changes

Notable changes:
* genesis