### PR TITLE
feat: restrict token transfers to payment accounts

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -13,9 +13,10 @@ import (
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
+	"github.com/spf13/cast"
+
 	"github.com/cosmos/cosmos-sdk/x/crosschain"
 	"github.com/cosmos/cosmos-sdk/x/oracle"
-	"github.com/spf13/cast"
 
 	crosschainkeeper "github.com/cosmos/cosmos-sdk/x/crosschain/keeper"
 	crosschaintypes "github.com/cosmos/cosmos-sdk/x/crosschain/types"
@@ -415,7 +416,7 @@ func NewSimApp(
 		),
 		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
 		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
-		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
+		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, nil, app.GetSubspace(banktypes.ModuleName)),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper, false),
 		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),

--- a/tests/integration/bank/keeper/keeper_test.go
+++ b/tests/integration/bank/keeper/keeper_test.go
@@ -75,7 +75,7 @@ func newBarCoin(amt int64) sdk.Coin {
 	return sdk.NewInt64Coin(barDenom, amt)
 }
 
-//nolint: interfacer
+// nolint: interfacer
 func getCoinsByName(ctx sdk.Context, bk keeper.Keeper, ak types.AccountKeeper, moduleName string) sdk.Coins {
 	moduleAddress := ak.GetModuleAddress(moduleName)
 	macc := ak.GetAccount(ctx, moduleAddress)
@@ -150,7 +150,7 @@ func (suite *IntegrationTestSuite) SetupTest() {
 	types.RegisterInterfaces(interfaceRegistry)
 
 	suite.queryClient = queryClient
-	suite.msgServer = keeper.NewMsgServerImpl(suite.bankKeeper)
+	suite.msgServer = keeper.NewMsgServerImpl(suite.bankKeeper, nil)
 }
 
 func (suite *IntegrationTestSuite) TestSupply() {

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -111,7 +111,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	queryClient := banktypes.NewQueryClient(queryHelper)
 
 	suite.queryClient = queryClient
-	suite.msgServer = keeper.NewMsgServerImpl(suite.bankKeeper)
+	suite.msgServer = keeper.NewMsgServerImpl(suite.bankKeeper, nil)
 	suite.encCfg = encCfg
 }
 

--- a/x/bank/keeper/msg_server.go
+++ b/x/bank/keeper/msg_server.go
@@ -82,6 +82,7 @@ func (k msgServer) MultiSend(goCtx context.Context, msg *types.MsgMultiSend) (*t
 		}
 	}
 
+	isUpgradeNagqu := ctx.IsUpgraded(upgradetypes.Nagqu)
 	for _, out := range msg.Outputs {
 		accAddr := sdk.MustAccAddressFromHex(out.Address)
 
@@ -89,7 +90,7 @@ func (k msgServer) MultiSend(goCtx context.Context, msg *types.MsgMultiSend) (*t
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", out.Address)
 		}
 
-		if ctx.IsUpgraded(upgradetypes.Nagqu) {
+		if isUpgradeNagqu {
 			if k.PaymentKeeper != nil && k.PaymentKeeper.IsPaymentAccount(ctx, accAddr) {
 				return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "payment account %s is not allowed to receive funds", accAddr)
 			}

--- a/x/bank/keeper/msg_server.go
+++ b/x/bank/keeper/msg_server.go
@@ -10,18 +10,20 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 type msgServer struct {
 	Keeper
+	PaymentKeeper types.PaymentKeeper
 }
 
 var _ types.MsgServer = msgServer{}
 
 // NewMsgServerImpl returns an implementation of the bank MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper) types.MsgServer {
-	return &msgServer{Keeper: keeper}
+func NewMsgServerImpl(keeper Keeper, paymentKeeper types.PaymentKeeper) types.MsgServer {
+	return &msgServer{Keeper: keeper, PaymentKeeper: paymentKeeper}
 }
 
 func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSendResponse, error) {
@@ -42,6 +44,12 @@ func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSe
 
 	if k.BlockedAddr(to) {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", msg.ToAddress)
+	}
+
+	if ctx.IsUpgraded(upgradetypes.Nagqu) {
+		if k.PaymentKeeper != nil && k.PaymentKeeper.IsPaymentAccount(ctx, to) {
+			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "payment account %s is not allowed to receive funds", msg.ToAddress)
+		}
 	}
 
 	err = k.SendCoins(ctx, from, to, msg.Amount)
@@ -79,6 +87,12 @@ func (k msgServer) MultiSend(goCtx context.Context, msg *types.MsgMultiSend) (*t
 
 		if k.BlockedAddr(accAddr) {
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", out.Address)
+		}
+
+		if ctx.IsUpgraded(upgradetypes.Nagqu) {
+			if k.PaymentKeeper != nil && k.PaymentKeeper.IsPaymentAccount(ctx, accAddr) {
+				return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "payment account %s is not allowed to receive funds", accAddr)
+			}
 		}
 	}
 

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -100,6 +100,7 @@ type AppModule struct {
 
 	keeper        keeper.Keeper
 	accountKeeper types.AccountKeeper
+	paymentKeeper types.PaymentKeeper
 
 	// legacySubspace is used solely for migration of x/params managed parameters
 	legacySubspace exported.Subspace
@@ -115,7 +116,7 @@ func (am AppModule) IsAppModule() {}
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, am.paymentKeeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	m := keeper.NewMigrator(am.keeper.(keeper.BaseKeeper), am.legacySubspace)
@@ -133,11 +134,12 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, accountKeeper types.AccountKeeper, ss exported.Subspace) AppModule {
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, accountKeeper types.AccountKeeper, paymentKeeper types.PaymentKeeper, ss exported.Subspace) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{cdc: cdc},
 		keeper:         keeper,
 		accountKeeper:  accountKeeper,
+		paymentKeeper:  paymentKeeper,
 		legacySubspace: ss,
 	}
 }
@@ -254,7 +256,7 @@ func ProvideModule(in BankInputs) BankOutputs {
 		blockedAddresses,
 		authority.String(),
 	)
-	m := NewAppModule(in.Cdc, bankKeeper, in.AccountKeeper, in.LegacySubspace)
+	m := NewAppModule(in.Cdc, bankKeeper, in.AccountKeeper, nil, in.LegacySubspace)
 
 	return BankOutputs{BankKeeper: bankKeeper, Module: m}
 }

--- a/x/bank/testutil/expected_keepers_mocks.go
+++ b/x/bank/testutil/expected_keepers_mocks.go
@@ -226,3 +226,40 @@ func (mr *MockAccountKeeperMockRecorder) ValidatePermissions(macc interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePermissions", reflect.TypeOf((*MockAccountKeeper)(nil).ValidatePermissions), macc)
 }
+
+// MockPaymentKeeper is a mock of PaymentKeeper interface.
+type MockPaymentKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockPaymentKeeperMockRecorder
+}
+
+// MockPaymentKeeperMockRecorder is the mock recorder for MockPaymentKeeper.
+type MockPaymentKeeperMockRecorder struct {
+	mock *MockPaymentKeeper
+}
+
+// NewMockPaymentKeeper creates a new mock instance.
+func NewMockPaymentKeeper(ctrl *gomock.Controller) *MockPaymentKeeper {
+	mock := &MockPaymentKeeper{ctrl: ctrl}
+	mock.recorder = &MockPaymentKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPaymentKeeper) EXPECT() *MockPaymentKeeperMockRecorder {
+	return m.recorder
+}
+
+// IsPaymentAccount mocks base method.
+func (m *MockPaymentKeeper) IsPaymentAccount(ctx types.Context, addr types.AccAddress) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPaymentAccount", ctx, addr)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPaymentAccount indicates an expected call of IsPaymentAccount.
+func (mr *MockPaymentKeeperMockRecorder) IsPaymentAccount(ctx, addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPaymentAccount", reflect.TypeOf((*MockPaymentKeeper)(nil).IsPaymentAccount), ctx, addr)
+}

--- a/x/bank/types/expected_keepers.go
+++ b/x/bank/types/expected_keepers.go
@@ -27,3 +27,10 @@ type AccountKeeper interface {
 	SetModuleAccount(ctx sdk.Context, macc types.ModuleAccountI)
 	GetModulePermissions() map[string]types.PermissionsForAddress
 }
+
+type PaymentKeeper interface {
+	IsPaymentAccount(
+		ctx sdk.Context,
+		addr sdk.AccAddress,
+	) bool
+}


### PR DESCRIPTION
### Description

This pr will restrict token transfers to payment accounts in greenfield. 

The payment accounts are derived from the owner account with an index, the tokens transferred to the payment accounts will lost since there is no private key for the accounts. This pr will restrict direct token transfer to the payment accounts to prevent token lost.

### Rationale

Restrict token transfers to payment accounts in greenfield. 

### Example

n/a

### Changes

Notable changes:
* restrict token transfers to payment accounts in greenfield
