### PR TITLE
fix: disable pre deliver when raw db store is used

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -545,8 +545,10 @@ func (app *BaseApp) PreBeginBlock(req abci.RequestPreBeginBlock) (res abci.Respo
 		app.cms.SetTracingContext(map[string]interface{}{"blockHeight": req.Header.Height})
 	}
 
-	// Initialize the preDeliverTx state.
-	app.setPreState(req.StateNumber, req.Header)
+	if app.IsIavlStore() {
+		// Initialize the preDeliverTx state.
+		app.setPreState(req.StateNumber, req.Header)
+	}
 
 	res = abci.ResponsePrefetch{Code: abci.CodeTypeOK}
 	return
@@ -558,6 +560,10 @@ func (app *BaseApp) PreDeliverTx(req abci.RequestPreDeliverTx) {
 			return
 		}
 	}()
+
+	if !app.IsIavlStore() {
+		return
+	}
 
 	preState := app.preDeliverStates[req.StateIndex]
 	if preState == nil {
@@ -580,7 +586,9 @@ func (app *BaseApp) PreCommit(req abci.RequestPreCommit) (res abci.ResponsePrefe
 		}
 	}()
 
-	app.preDeliverStates[req.StateIndex].ms.Write()
+	if app.IsIavlStore() {
+		app.preDeliverStates[req.StateIndex].ms.Write()
+	}
 
 	res = abci.ResponsePrefetch{Code: abci.CodeTypeOK}
 	return

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -574,7 +574,7 @@ func (rs *Store) DeepCopyAndCache() types.CacheMultiStore {
 		} else if _, ok := v.(*transient.Store); ok {
 			stores[k] = transient.NewStore()
 		} else if dbStore, ok := v.(commitDBStoreAdapter); ok {
-			stores[k] = commitDBStoreAdapter{Store: dbadapter.Store{DB: dbStore.Store.DB}}
+			stores[k] = cache.NewCommitKVStoreCache(commitDBStoreAdapter{Store: dbadapter.Store{DB: dbStore.Store.DB}}, 1000).CommitKVStore
 		}
 	}
 	return cachemulti.NewStore(rs.db, stores, rs.keysByName, rs.traceWriter, rs.getTracingContext())
@@ -598,7 +598,7 @@ func (rs *Store) DeepCopy() *Store {
 		} else if _, ok := v.(*transient.Store); ok {
 			stores[k] = transient.NewStore()
 		} else if dbStore, ok := v.(commitDBStoreAdapter); ok {
-			stores[k] = commitDBStoreAdapter{Store: dbadapter.Store{DB: dbStore.Store.DB}}
+			stores[k] = cache.NewCommitKVStoreCache(commitDBStoreAdapter{Store: dbadapter.Store{DB: dbStore.Store.DB}}, 1000).CommitKVStore
 		}
 	}
 


### PR DESCRIPTION
### Description

When using raw db store (no IAVL), the `Write()` function could write dirty data into the underlying store.
Thus we need to disable pre-deliver when raw db store is used.

### Rationale

Bug fix

### Example

NA

### Changes

Notable changes:
* disable pre-deliver