### PR TITLE
release: draft release for v0.2.4  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
 # Changelog
 
 ## v0.2.4
-This release includes all the changes in the v0.2.4 alpha versions, along with 2 new features and 2 new bugfixes.
-
-Features:
-* [#277#288](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) Revert "feat: restrict token transfers to payment accounts
-* [#277](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) feat: restrict token transfers to payment accounts
+This release includes all the changes in the v0.2.4 alpha versions and 2 new bugfixes.
 
 Bugfixes:
 * [#281](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/281) fix: disable pre deliver when raw db store is used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.2.4
+This release includes all the changes in the v0.2.4 alpha versions, along with 2 new features and 2 new bugfixes.
+
+Features:
+* [#277#288](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) Revert "feat: restrict token transfers to payment accounts
+* [#277](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) feat: restrict token transfers to payment accounts
+
+Bugfixes:
+* [#281](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/281) fix: disable pre deliver when raw db store is used
+* [#287](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/287) fix: fix dependency security issues
+
+Chores:
+* [#289](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/289) chore: modify code comments in VerifySignature
+
 ## v0.2.4-alpha.2
 This release includes 5 new features.
 

--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
 
-	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.3-alpha.1
+	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v0.0.3
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsy
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield-cometbft v0.0.3-alpha.1 h1:nCLXxYdkDIh5bQMxtb14TBwiut/xq2e0DqPVTLy9vtI=
-github.com/bnb-chain/greenfield-cometbft v0.0.3-alpha.1/go.mod h1:3nGT4Z9fHwgRlBY/rofn0rSarnIcNbuhz/eq0XlLlkg=
+github.com/bnb-chain/greenfield-cometbft v0.0.3 h1:tv8NMy3bzX/1urqXGQIIAZSLy83loiI+dG0VKeyh1CY=
+github.com/bnb-chain/greenfield-cometbft v0.0.3/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
 github.com/bnb-chain/greenfield-iavl v0.20.1 h1:y3L64GU99otNp27/xLVBTDbv4eroR6CzoYz0rbaVotM=
@@ -1441,8 +1441,8 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
 github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
-github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b+d8w=
 github.com/opencontainers/runc v1.1.3/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
+github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/GDEs=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=


### PR DESCRIPTION
### Description

This release includes all the changes in the v0.2.4 alpha versions and 2 new bugfixes.

### Rationale

Bugfixes:
* [#281](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/281) fix: disable pre deliver when raw db store is used
* [#287](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/287) fix: fix dependency security issues

Chores:
* [#289](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/289) chore: modify code comments in VerifySignature

### Example

Please refer to the PRs for detailed information.  

### Changes

Notable changes: 
none  