### PR TITLE
release: prepare release for v0.2.5-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.2.5-alpha.1
+This release includes 1 feature and 1 chore.
+
+Features:
+* [#277](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) feat: restrict token transfers to payment accounts
+
+Chores:
+* [#300](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/300) chore: add hardfork logic for Nagqu
+
 ## v0.2.4
 This release includes all the changes in the v0.2.4 alpha versions and 2 new bugfixes.
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -13,9 +13,10 @@ import (
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
+	"github.com/spf13/cast"
+
 	"github.com/cosmos/cosmos-sdk/x/crosschain"
 	"github.com/cosmos/cosmos-sdk/x/oracle"
-	"github.com/spf13/cast"
 
 	crosschainkeeper "github.com/cosmos/cosmos-sdk/x/crosschain/keeper"
 	crosschaintypes "github.com/cosmos/cosmos-sdk/x/crosschain/types"
@@ -415,7 +416,7 @@ func NewSimApp(
 		),
 		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
 		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
-		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
+		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, nil, app.GetSubspace(banktypes.ModuleName)),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper, false),
 		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),

--- a/store/types/gas.go
+++ b/store/types/gas.go
@@ -261,6 +261,19 @@ type GasConfig struct {
 	IterNextCostFlat Gas
 }
 
+// KVGasConfigAfterNagqu returns a gas config after Nagqu harfork for KVStores.
+func KVGasConfigAfterNagqu() GasConfig {
+	return GasConfig{
+		HasCost:          0,
+		DeleteCost:       1000,
+		ReadCostFlat:     0,
+		ReadCostPerByte:  0,
+		WriteCostFlat:    2000,
+		WriteCostPerByte: 30,
+		IterNextCostFlat: 0,
+	}
+}
+
 // KVGasConfig returns a default gas config for KVStores.
 func KVGasConfig() GasConfig {
 	return GasConfig{

--- a/tests/integration/bank/keeper/keeper_test.go
+++ b/tests/integration/bank/keeper/keeper_test.go
@@ -75,7 +75,7 @@ func newBarCoin(amt int64) sdk.Coin {
 	return sdk.NewInt64Coin(barDenom, amt)
 }
 
-//nolint: interfacer
+// nolint: interfacer
 func getCoinsByName(ctx sdk.Context, bk keeper.Keeper, ak types.AccountKeeper, moduleName string) sdk.Coins {
 	moduleAddress := ak.GetModuleAddress(moduleName)
 	macc := ak.GetAccount(ctx, moduleAddress)
@@ -150,7 +150,7 @@ func (suite *IntegrationTestSuite) SetupTest() {
 	types.RegisterInterfaces(interfaceRegistry)
 
 	suite.queryClient = queryClient
-	suite.msgServer = keeper.NewMsgServerImpl(suite.bankKeeper)
+	suite.msgServer = keeper.NewMsgServerImpl(suite.bankKeeper, nil)
 }
 
 func (suite *IntegrationTestSuite) TestSupply() {

--- a/types/context.go
+++ b/types/context.go
@@ -313,13 +313,24 @@ func (c Context) Value(key interface{}) interface{} {
 // Store / Caching
 // ----------------------------------------------------------------------------
 
+// KVStoreWithZeroRead fetches a KVStore from the MultiStore.
+func (c Context) KVStoreWithZeroRead(key storetypes.StoreKey) storetypes.KVStore {
+	return gaskv.NewStore(c.MultiStore().GetKVStore(key), c.gasMeter, storetypes.KVGasConfigAfterNagqu())
+}
+
 // KVStore fetches a KVStore from the MultiStore.
 func (c Context) KVStore(key storetypes.StoreKey) storetypes.KVStore {
+	if c.upgradeChecker != nil && c.upgradeChecker(c, Nagqu) {
+		return gaskv.NewStore(c.MultiStore().GetKVStore(key), c.gasMeter, storetypes.KVGasConfigAfterNagqu())
+	}
 	return gaskv.NewStore(c.MultiStore().GetKVStore(key), c.gasMeter, c.kvGasConfig)
 }
 
 // TransientStore fetches a TransientStore from the MultiStore.
 func (c Context) TransientStore(key storetypes.StoreKey) storetypes.KVStore {
+	if c.upgradeChecker != nil && c.upgradeChecker(c, Nagqu) {
+		return c.MultiStore().GetKVStore(key)
+	}
 	return gaskv.NewStore(c.MultiStore().GetKVStore(key), c.gasMeter, c.kvGasConfig)
 }
 

--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -1,0 +1,9 @@
+package types
+
+const (
+	// EnablePublicDelegationUpgrade is the upgrade name for enabling public delegation
+	EnablePublicDelegationUpgrade = "EnablePublicDelegationUpgrade"
+
+	// Nagqu is the upgrade name for following features:
+	Nagqu = "Nagqu"
+)

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -111,7 +111,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	queryClient := banktypes.NewQueryClient(queryHelper)
 
 	suite.queryClient = queryClient
-	suite.msgServer = keeper.NewMsgServerImpl(suite.bankKeeper)
+	suite.msgServer = keeper.NewMsgServerImpl(suite.bankKeeper, nil)
 	suite.encCfg = encCfg
 }
 

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -100,6 +100,7 @@ type AppModule struct {
 
 	keeper        keeper.Keeper
 	accountKeeper types.AccountKeeper
+	paymentKeeper types.PaymentKeeper
 
 	// legacySubspace is used solely for migration of x/params managed parameters
 	legacySubspace exported.Subspace
@@ -115,7 +116,7 @@ func (am AppModule) IsAppModule() {}
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper, am.paymentKeeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	m := keeper.NewMigrator(am.keeper.(keeper.BaseKeeper), am.legacySubspace)
@@ -133,11 +134,12 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, accountKeeper types.AccountKeeper, ss exported.Subspace) AppModule {
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, accountKeeper types.AccountKeeper, paymentKeeper types.PaymentKeeper, ss exported.Subspace) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{cdc: cdc},
 		keeper:         keeper,
 		accountKeeper:  accountKeeper,
+		paymentKeeper:  paymentKeeper,
 		legacySubspace: ss,
 	}
 }
@@ -254,7 +256,7 @@ func ProvideModule(in BankInputs) BankOutputs {
 		blockedAddresses,
 		authority.String(),
 	)
-	m := NewAppModule(in.Cdc, bankKeeper, in.AccountKeeper, in.LegacySubspace)
+	m := NewAppModule(in.Cdc, bankKeeper, in.AccountKeeper, nil, in.LegacySubspace)
 
 	return BankOutputs{BankKeeper: bankKeeper, Module: m}
 }

--- a/x/bank/testutil/expected_keepers_mocks.go
+++ b/x/bank/testutil/expected_keepers_mocks.go
@@ -226,3 +226,40 @@ func (mr *MockAccountKeeperMockRecorder) ValidatePermissions(macc interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePermissions", reflect.TypeOf((*MockAccountKeeper)(nil).ValidatePermissions), macc)
 }
+
+// MockPaymentKeeper is a mock of PaymentKeeper interface.
+type MockPaymentKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockPaymentKeeperMockRecorder
+}
+
+// MockPaymentKeeperMockRecorder is the mock recorder for MockPaymentKeeper.
+type MockPaymentKeeperMockRecorder struct {
+	mock *MockPaymentKeeper
+}
+
+// NewMockPaymentKeeper creates a new mock instance.
+func NewMockPaymentKeeper(ctrl *gomock.Controller) *MockPaymentKeeper {
+	mock := &MockPaymentKeeper{ctrl: ctrl}
+	mock.recorder = &MockPaymentKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPaymentKeeper) EXPECT() *MockPaymentKeeperMockRecorder {
+	return m.recorder
+}
+
+// IsPaymentAccount mocks base method.
+func (m *MockPaymentKeeper) IsPaymentAccount(ctx types.Context, addr types.AccAddress) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPaymentAccount", ctx, addr)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPaymentAccount indicates an expected call of IsPaymentAccount.
+func (mr *MockPaymentKeeperMockRecorder) IsPaymentAccount(ctx, addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPaymentAccount", reflect.TypeOf((*MockPaymentKeeper)(nil).IsPaymentAccount), ctx, addr)
+}

--- a/x/bank/types/expected_keepers.go
+++ b/x/bank/types/expected_keepers.go
@@ -27,3 +27,10 @@ type AccountKeeper interface {
 	SetModuleAccount(ctx sdk.Context, macc types.ModuleAccountI)
 	GetModulePermissions() map[string]types.PermissionsForAddress
 }
+
+type PaymentKeeper interface {
+	IsPaymentAccount(
+		ctx sdk.Context,
+		addr sdk.AccAddress,
+	) bool
+}

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -249,7 +249,7 @@ func encodeDoneKey(name string, height int64) []byte {
 
 // GetDoneHeight returns the height at which the given upgrade was executed
 func (k Keeper) GetDoneHeight(ctx sdk.Context, name string) int64 {
-	iter := sdk.KVStorePrefixIterator(ctx.KVStore(k.storeKey), []byte{types.DoneByte})
+	iter := sdk.KVStorePrefixIterator(ctx.KVStoreWithZeroRead(k.storeKey), []byte{types.DoneByte})
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -2,14 +2,16 @@ package types
 
 import (
 	"math"
+
+	"github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
 	// EnablePublicDelegationUpgrade is the upgrade name for enabling public delegation
-	EnablePublicDelegationUpgrade = "EnablePublicDelegationUpgrade"
+	EnablePublicDelegationUpgrade = types.EnablePublicDelegationUpgrade
 
 	// Nagqu is the upgrade name for following features:
-	Nagqu = "Nagqu"
+	Nagqu = types.Nagqu
 )
 
 // The default upgrade config for networks


### PR DESCRIPTION
### Description

This release includes 1 feature and 1 chore.

### Rationale

Features:
* [#277](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) feat: restrict token transfers to payment accounts

Chores:
* [#300](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/300) chore: add hardfork logic for Nagqu


### Example

NA

### Changes

Notable changes:
* changelogs