### PR TITLE
feat: enable Nagqu hardfork to testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.2.5
+This release includes all the changes in the v0.2.5 alpha versions.
+Features:
+* [#277](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) feat: restrict token transfers to payment accounts
+* [#306](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/306) feat: enable Nagqu hardfork to testnet
+
+Chores:
+* [#300](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/300) chore: add hardfork logic for Nagqu
+
 ## v0.2.5-alpha.1
 This release includes 1 feature and 1 chore.
 

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -17,12 +17,11 @@ const (
 // The default upgrade config for networks
 var (
 	TestnetChainID = "greenfield_5600-1"
-	TestnetConfig  = NewUpgradeConfig()
-	// .SetPlan(&Plan{
-	// 	Name: EnablePublicDelegationUpgrade,
-	// 	Height: 100,
-	// 	Info: "Enable public delegation",
-	// })
+	TestnetConfig  = NewUpgradeConfig().SetPlan(&Plan{
+		Name:   Nagqu,
+		Height: 471350,
+		Info:   "Nagqu hardfork",
+	})
 )
 
 func NewUpgradeConfig() *UpgradeConfig {


### PR DESCRIPTION
### Description

enable Nagqu hardfork to testnet

### Rationale

1694488975 (2023-9-12 03:22:55 AM +UTC) - block: 366648 ([greenfieldscan](https://greenfieldscan.com/block/366648))

1694761200 (2023-9-15 07:00:00 AM +UTC)

AvgBlockTime: 2.6s
(1694761200 - 1694488975)/2.6 + 366648 ~= 471350


### Example

N/A

### Changes

Notable changes:
* upgrade
* changelog