### PR TITLE
release: prepare release for v0.2.5  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## v0.2.5
-This release includes all the changes in the v0.2.5 alpha versions.
+## v0.2.5  
+
+This release includes all the changes in the v0.2.5 alpha versions and 1 new feature.
+
 Features:
+* [#306](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/306) feat: enable Nagqu hardfork to testnet  
 * [#277](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) feat: restrict token transfers to payment accounts
-* [#306](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/306) feat: enable Nagqu hardfork to testnet
 
 Chores:
 * [#300](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/300) chore: add hardfork logic for Nagqu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.2.5
+This release includes all the changes in the v0.2.5 alpha versions.
+Features:
+* [#277](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) feat: restrict token transfers to payment accounts
+* [#306](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/306) feat: enable Nagqu hardfork to testnet
+
+Chores:
+* [#300](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/300) chore: add hardfork logic for Nagqu
+
 ## v0.2.5-alpha.1
 This release includes 1 feature and 1 chore.
 

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -17,12 +17,11 @@ const (
 // The default upgrade config for networks
 var (
 	TestnetChainID = "greenfield_5600-1"
-	TestnetConfig  = NewUpgradeConfig()
-	// .SetPlan(&Plan{
-	// 	Name: EnablePublicDelegationUpgrade,
-	// 	Height: 100,
-	// 	Info: "Enable public delegation",
-	// })
+	TestnetConfig  = NewUpgradeConfig().SetPlan(&Plan{
+		Name:   Nagqu,
+		Height: 471350,
+		Info:   "Nagqu hardfork",
+	})
 )
 
 func NewUpgradeConfig() *UpgradeConfig {


### PR DESCRIPTION
### Description

This release includes all the changes in the v0.2.5 alpha versions and 1 new feature.

### Rationale

Features:
* [#306](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/306) feat: enable Nagqu hardfork to testnet  
* [#277](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/277) feat: restrict token transfers to payment accounts

Chores:
* [#300](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/300) chore: add hardfork logic for Nagqu

### Example

Please refer to the PRs for detailed information.  

### Changes

Notable changes: 
none  