### PR TITLE
fix: restrict pagination limit

### DIFF
--- a/types/query/filtered_pagination.go
+++ b/types/query/filtered_pagination.go
@@ -151,7 +151,7 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		return results, nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
 
-	if limit == 0 {
+	if limit == 0 || limit > DefaultLimit {
 		limit = DefaultLimit
 
 		// count total results when the limit is zero/not supplied


### PR DESCRIPTION
### Description

As some queries are using `GenericFilteredPaginate`, restrict the pagination limit to 100

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...