### PR TITLE
feat: add validation with context information

### DIFF
--- a/baseapp/msg_service_router.go
+++ b/baseapp/msg_service_router.go
@@ -122,6 +122,12 @@ func (msr *MsgServiceRouter) RegisterService(sd *grpc.ServiceDesc, handler inter
 				return nil, err
 			}
 
+			if runtimeReq, ok := req.(sdk.MsgWithRuntimeValidation); ok {
+				if err := runtimeReq.ValidateRuntime(ctx); err != nil {
+					return nil, err
+				}
+			}
+
 			if msr.circuitBreaker != nil {
 				msgURL := sdk.MsgTypeURL(req)
 

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -25,6 +25,17 @@ type (
 		GetSigners() []AccAddress
 	}
 
+	// MsgWithRuntimeValidation defines the interface a transaction message which wants to enable runtime validation.
+	// Contract: enable runtime validation after Xxxx upgrade.
+	MsgWithRuntimeValidation interface {
+		Msg
+
+		// ValidateRuntime does a simple validation, different from ValidateBasic the context information
+		// will be used to facilitate validation for hardfork.
+		// Contract: only used for simple validation which needs hardfork logic.
+		ValidateRuntime(ctx Context) error
+	}
+
 	// Fee defines an interface for an application application-defined concrete
 	// transaction type to be able to set and return the transaction fee.
 	Fee interface {

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -26,7 +26,7 @@ type (
 	}
 
 	// MsgWithRuntimeValidation defines the interface a transaction message which wants to enable runtime validation.
-	// Contract: enable runtime validation after Xxxx upgrade.
+	// Contract: enable runtime validation after Pampas upgrade.
 	MsgWithRuntimeValidation interface {
 		Msg
 

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -43,6 +43,12 @@ func (k Keeper) SubmitProposal(ctx sdk.Context, messages []sdk.Msg, metadata, ti
 			return v1.Proposal{}, sdkerrors.Wrap(types.ErrInvalidProposalMsg, err.Error())
 		}
 
+		if runtimeMsg, ok := msg.(sdk.MsgWithRuntimeValidation); ok {
+			if err := runtimeMsg.ValidateRuntime(ctx); err != nil {
+				return v1.Proposal{}, sdkerrors.Wrap(types.ErrInvalidProposalMsg, err.Error())
+			}
+		}
+
 		signers := msg.GetSigners()
 		if len(signers) != 1 {
 			return v1.Proposal{}, types.ErrInvalidSigner


### PR DESCRIPTION
### Description

Some validations are needed for different hardforks. 
`ValidateBasic` does not have information to detect hardforks.
`ValidateRuntime` can be used for validations with hardfork information. 

### Rationale

New feature

### Example

NA

### Changes

Notable changes:
* `ValidateRuntime` function