### PR TITLE
release: prepare release for v0.2.6-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.6
+This release caps the pagination limit for queries at 100 records if it exceeds the default pagination limit.
+
+* [#315](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/315) fix: restrict pagination limit  
+
 ## v0.2.6-alpha.1
 This release includes 1 new feature.
 

--- a/types/query/filtered_pagination.go
+++ b/types/query/filtered_pagination.go
@@ -151,7 +151,7 @@ func GenericFilteredPaginate[T codec.ProtoMarshaler, F codec.ProtoMarshaler](
 		return results, nil, fmt.Errorf("invalid request, either offset or key is expected, got both")
 	}
 
-	if limit == 0 {
+	if limit == 0 || limit > DefaultLimit {
 		limit = DefaultLimit
 
 		// count total results when the limit is zero/not supplied


### PR DESCRIPTION
### Description

This release caps the pagination limit for queries at 100 records if it exceeds the default pagination limit.

### Rationale

* [#315](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/315) fix: restrict pagination limit  

### Example

Please refer to individual PRs for detailed information.  

### Changes

Notable changes:
none