### PR TITLE
release: draft release for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.0
+This release includes 1 new feature.
+
+* [#317](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/317) feat: add Nagqu fork to mainnet
+
 ## v0.2.6
 This release caps the pagination limit for queries at 100 records if it exceeds the default pagination limit.
 


### PR DESCRIPTION
### Description

This release is the official release for the Greenfield mainnet.

### Rationale

This release includes 1 new feature.

* [#317](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/317) feat: add Nagqu fork to mainnet

### Example

NA

### Changes

Notable changes:
* add upgrade config