### PR TITLE
release: prepare release for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.0
+This release includes 1 new feature.
+
+* [#317](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/317) feat: add Nagqu fork to mainnet
+
 ## v0.2.6
 This release caps the pagination limit for queries at 100 records if it exceeds the default pagination limit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 ## v1.0.0
-This release includes 1 new feature.
+This release includes 2 new features.
 
 * [#317](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/317) feat: add Nagqu fork to mainnet
+* [#323](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/323) feat: support multi msg for `PrintEIP712MsgType` flag
 
 ## v0.2.6
 This release caps the pagination limit for queries at 100 records if it exceeds the default pagination limit.

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -462,6 +462,8 @@ func (keeper *Keeper) RegisterUpgradePlan(chianID string, plans []serverconfig.U
 // getExistChainConfig returns the exist chain config
 func getExistChainConfig(chainID string) *types.UpgradeConfig {
 	switch chainID {
+	case types.MainnetChainID:
+		return types.MainnetConfig
 	case types.TestnetChainID:
 		return types.TestnetConfig
 	default:

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -16,6 +16,13 @@ const (
 
 // The default upgrade config for networks
 var (
+	MainnetChainID = "greenfield_1017-1"
+	MainnetConfig  = NewUpgradeConfig().SetPlan(&Plan{
+		Name:   Nagqu,
+		Height: 1,
+		Info:   "Nagqu hardfork",
+	})
+
 	TestnetChainID = "greenfield_5600-1"
 	TestnetConfig  = NewUpgradeConfig().SetPlan(&Plan{
 		Name:   Nagqu,


### PR DESCRIPTION
### Description

This release is the official release of greenfield-cosmos-sdk for the Greenfield mainnet.

This release includes 2 new features.

* [#317](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/317) feat: add Nagqu fork to mainnet
* [#323](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/323) feat: support multi msg for `PrintEIP712MsgType` flag

### Rationale

Release

### Example

NA

### Changes

Notable changes:
* add upgrade config