### PR TITLE
fix: do not count total when pagination request is empty

### DIFF
--- a/types/query/pagination.go
+++ b/types/query/pagination.go
@@ -81,9 +81,8 @@ func Paginate(
 
 	if limit == 0 {
 		limit = DefaultLimit
-
-		// count total results when the limit is zero/not supplied
-		countTotal = true
+		// do not count total results when the limit is zero/not supplied
+		// countTotal = true
 	} else if limit > DefaultLimit {
 		// limit to protect the node would not be Query DoS
 		limit = DefaultLimit

--- a/types/query/pagination_test.go
+++ b/types/query/pagination_test.go
@@ -122,7 +122,8 @@ func (s *paginationTestSuite) TestPagination() {
 	request := types.NewQueryAllBalancesRequest(addr1, pageReq)
 	res, err := queryClient.AllBalances(gocontext.Background(), request)
 	s.Require().NoError(err)
-	s.Require().Equal(res.Pagination.Total, uint64(numBalances))
+	// default page request will not return total count
+	// s.Require().Equal(res.Pagination.Total, uint64(numBalances))
 	s.Require().NotNil(res.Pagination.NextKey)
 	s.Require().LessOrEqual(res.Balances.Len(), defaultLimit)
 


### PR DESCRIPTION
### Description

Currently, if the pagination request is empty. It will count total, which is very time consuming. 

### Rationale

Fix query issue

### Example

```
❯ curl -X GET "http://localhost:1317/greenfield/storage/list_buckets?pagination.limit=10" -H  "accept: application/json"
{"bucket_infos":[{"owner":"0x84A0d38d64498414B14cD979159D57557345Cd8B","bucket_name":"hek10","visibility":"VISIBILITY_TYPE_PRIVATE","id":"1","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693474466","payment_address":"0x84A0d38d64498414B14cD979159D57557345Cd8B","global_virtual_group_family_id":1,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test8","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"256","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693762884","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":7,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test9","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"257","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693763243","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":7,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test10","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"258","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693763518","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":7,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test11","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"259","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693763781","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":1,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test12","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"260","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693763938","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":1,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test13","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"261","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693765060","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":1,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test14","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"262","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693765514","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":6,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test15","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"263","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693766126","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":1,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"},{"owner":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","bucket_name":"test16","visibility":"VISIBILITY_TYPE_PUBLIC_READ","id":"264","source_type":"SOURCE_TYPE_ORIGIN","create_at":"1693766581","payment_address":"0x8FFBa7FB87E3405ce4239D308C033B8E3fBA2106","global_virtual_group_family_id":6,"charged_read_quota":"0","bucket_status":"BUCKET_STATUS_CREATED"}],"pagination":{"next_key":"AQk=","total":"0"}}
```

### Changes

Notable changes:
* change default value of `count_total`