### PR TITLE
release: prepare release for v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.1
+This release includes 1 bug fix.
+
+* [#338](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/338) fix: count total when pagination request is empty
+
 ## v1.0.0
 This release includes 2 new features.
 


### PR DESCRIPTION
### Description

This pr will release v1.0.1, which is a maintenance release.

### Rationale

Bug fix

* [#338](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/338) fix: count total when pagination request is empty

### Example

NA

### Changes

Notable changes:
* change log