### PR TITLE
feat: support Secp256k1 format private keys import

### DIFF
--- a/client/keys/import.go
+++ b/client/keys/import.go
@@ -21,7 +21,7 @@ const (
 // ImportKeyCommand imports private keys from a keyfile.
 func ImportKeyCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "import <name> <keyfile>/<pricateKey>",
+		Use:   "import <name> <keyfile>/<privateKey>",
 		Short: "Import private keys into the local keybase",
 		Long:  "Import a ASCII armored/Secp256k1 private key into the local keybase.",
 		Args:  cobra.ExactArgs(2),

--- a/client/keys/import.go
+++ b/client/keys/import.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	flagEIP712PrivateKey = "eip712-private-key"
+	flagSecp256k1PrivateKey = "secp256k1-private-key"
 )
 
 // ImportKeyCommand imports private keys from a keyfile.
@@ -23,7 +23,7 @@ func ImportKeyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import <name> <keyfile>/<pricateKey>",
 		Short: "Import private keys into the local keybase",
-		Long:  "Import a ASCII armored/EIP-712 private key into the local keybase.",
+		Long:  "Import a ASCII armored/Secp256k1 private key into the local keybase.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
@@ -31,17 +31,17 @@ func ImportKeyCommand() *cobra.Command {
 				return err
 			}
 
-			isEIP712, _ := cmd.Flags().GetBool(flagEIP712PrivateKey)
+			isSecp256k1, _ := cmd.Flags().GetBool(flagSecp256k1PrivateKey)
 
-			if !isEIP712 {
+			if !isSecp256k1 {
 				return importASCIIArmored(clientCtx, args)
 			}
 
-			return importEIP712(clientCtx, args)
+			return importSecp256k1(clientCtx, args)
 		},
 	}
 
-	cmd.Flags().Bool(flagEIP712PrivateKey, false, "import EIP-712 format private key")
+	cmd.Flags().Bool(flagSecp256k1PrivateKey, false, "import Secp256k1 format private key")
 
 	return cmd
 }
@@ -62,7 +62,7 @@ func importASCIIArmored(clientCtx client.Context, args []string) error {
 	return clientCtx.Keyring.ImportPrivKey(args[0], string(bz), passphrase)
 }
 
-func importEIP712(clientCtx client.Context, args []string) error {
+func importSecp256k1(clientCtx client.Context, args []string) error {
 	keyName := args[0]
 	keyBytes, err := hex.DecodeString(args[1])
 	if err != nil {

--- a/client/keys/import.go
+++ b/client/keys/import.go
@@ -75,6 +75,9 @@ func importSecp256k1(clientCtx client.Context, args []string) error {
 	copy(keyBytesArray[:], keyBytes[:32])
 	privKey := hd.EthSecp256k1.Generate()(keyBytesArray[:]).(*ethsecp256k1.PrivKey)
 
-	clientCtx.Keyring.WriteLocalKey(keyName, privKey)
+	_, err = clientCtx.Keyring.WriteLocalKey(keyName, privKey)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -116,6 +116,9 @@ type Importer interface {
 
 	// ImportPubKey imports ASCII armored public keys.
 	ImportPubKey(uid string, armor string) error
+
+	// WriteLocalKey persists a private key object into storage.
+	WriteLocalKey(name string, privKey types.PrivKey) (*Record, error)
 }
 
 // Migrator is implemented by key stores and enables migration of keys from amino to proto
@@ -755,6 +758,11 @@ func newRealPrompt(dir string, buf io.Reader) func(string) (string, error) {
 			return pass, nil
 		}
 	}
+}
+
+// WriteLocalKey persists a local key to the keyring.
+func (ks keystore) WriteLocalKey(name string, privKey types.PrivKey) (*Record, error) {
+	return ks.writeLocalKey(name, privKey)
 }
 
 func (ks keystore) writeLocalKey(name string, privKey types.PrivKey) (*Record, error) {


### PR DESCRIPTION
### Description

feat: support Secp256k1 private keys import

### Rationale

support Secp256k1 format private keys import via cmd

### Example

```bash
./build/bin/gnfd keys import testing 89319801b3f2d5cb... --home ./.local --secp256k1-private-key --keyring-backend test
./build/bin/gnfd keys list --home ./.local --keyring-backend test
```

<img width="904" alt="image" src="https://github.com/bnb-chain/greenfield-cosmos-sdk/assets/25412254/3cda8c16-2206-4b70-b0fc-d24d79adf3df">


### Changes

Notable changes:
* cmd