### PR TITLE
feat: enable Pampas hardfork to mainnet

### DIFF
--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -27,6 +27,10 @@ var (
 		Name:   Nagqu,
 		Height: 1,
 		Info:   "Nagqu hardfork",
+	}).SetPlan(&Plan{
+		Name:   Pampas,
+		Height: 2006197,
+		Info:   "Pampas hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"


### PR DESCRIPTION
Description
enable Nagqu hardfork to mainnet

Rationale
1700707216 (2023-11-23 02:40:16 AM +UTC)- block: 1634665 ([greenfieldscan](https://greenfieldscan.com/block/1634665))

Target Hardfork time:
1701673200 (2023-12-04 07:00:00 +UTC)

AvgBlockTime: 2.6s
(1701673200 - 1700707216)/2.6 + 1634665 ~= `2,006,197`

Example
N/A

Changes
Notable changes:
- upgrade
