### PR TITLE
release: prepare release for v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.1
+This release introduces the Pampas upgrade to the mainnet.  
+
+Features:
+* [#360](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/360) feat: enable Pampas hardfork to mainnet
+
 ## v1.1.0
 This release introduces the Pampas upgrade and contains 8 new features.  
 

--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -9,4 +9,7 @@ const (
 
 	// Pampas is the upgrade name for Pampas upgrade
 	Pampas = "Pampas"
+
+	// Eddystone is the upgrade name for Eddystone upgrade
+	Eddystone = "Eddystone"
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -27,6 +27,10 @@ var (
 		Name:   Nagqu,
 		Height: 1,
 		Info:   "Nagqu hardfork",
+	}).SetPlan(&Plan{
+		Name:   Pampas,
+		Height: 2006197,
+		Info:   "Pampas hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -15,6 +15,9 @@ const (
 
 	// Pampas is the upgrade name for Pampas upgrade
 	Pampas = types.Pampas
+
+	// Eddystone is the upgrade name for Eddystone upgrade
+	Eddystone = types.Eddystone
 )
 
 // The default upgrade config for networks


### PR DESCRIPTION
### Description

This release introduces the Pampas upgrade to the mainnet. 

### Rationale

Features:
* [#360](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/360) feat: enable Pampas hardfork to mainnet

### Example

n/a

### Changes

Notable changes:
none  
