### PR TITLE
feat: add xml marshal for Int type

### DIFF
--- a/math/int.go
+++ b/math/int.go
@@ -3,6 +3,7 @@ package math
 import (
 	"encoding"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"math/big"
 	"strings"
@@ -325,6 +326,20 @@ func MaxInt(i, i2 Int) Int {
 // Human readable string
 func (i Int) String() string {
 	return i.i.String()
+}
+
+// MarshalXML defines custom encoding for xml Marshaler
+func (i Int) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(i.String(), start)
+}
+
+// UnmarshalXML defines custom decoding for xml Marshaler
+func (i *Int) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var s string
+	if err := d.DecodeElement(&s, &start); err != nil {
+		return err
+	}
+	return i.Unmarshal([]byte(s))
 }
 
 // MarshalJSON defines custom encoding scheme

--- a/math/int_test.go
+++ b/math/int_test.go
@@ -2,6 +2,7 @@ package math_test
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -394,6 +395,14 @@ func (s *intTestSuite) TestIntEq() {
 	s.Require().True(resp)
 	_, resp, _, _, _ = math.IntEq(s.T(), math.OneInt(), math.ZeroInt())
 	s.Require().False(resp)
+}
+
+func (s *intTestSuite) TestIntXmlMarshalRoundTrip() {
+	u1 := math.NewInt(256)
+	marshalResult, _ := xml.Marshal(u1)
+	u2 := math.Int{}
+	xml.Unmarshal(marshalResult, &u2)
+	s.Require().Equal(u1, u2)
 }
 
 func TestRoundTripMarshalToInt(t *testing.T) {


### PR DESCRIPTION
### Description
feat: add xml marshal for Int type

### Rationale
When client uses golang/encoding/xml marshaler, it can't marshal cosmos Int type. So this PR will solve this problem.

### Example

```

func (s *intTestSuite) TestIntXmlMarshalRoundTrip() {
	u1 := math.NewInt(256)
	marshalResult, _ := xml.Marshal(u1)
	u2 := math.Int{}
	xml.Unmarshal(marshalResult, &u2)
	s.Require().Equal(u1, u2)
}

```
### Changes

Notable changes:
* add xml marshal and unmarshal methods for Int type
* add ut