### PR TITLE
release: prepare for release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## V1.2.0
+This release introduce the Manchurian upgrade to the testnet.
+
+Chores:
+* [#365](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/365) chore: add xml marshal for Int type
+* [#364](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/364) chore: add xml marshal for UInt type
+
 ## v1.1.1
 This release introduces the Pampas upgrade to the mainnet.  
 

--- a/math/int.go
+++ b/math/int.go
@@ -3,6 +3,7 @@ package math
 import (
 	"encoding"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"math/big"
 	"strings"
@@ -325,6 +326,20 @@ func MaxInt(i, i2 Int) Int {
 // Human readable string
 func (i Int) String() string {
 	return i.i.String()
+}
+
+// MarshalXML defines custom encoding for xml Marshaler
+func (i Int) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(i.String(), start)
+}
+
+// UnmarshalXML defines custom decoding for xml Marshaler
+func (i *Int) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var s string
+	if err := d.DecodeElement(&s, &start); err != nil {
+		return err
+	}
+	return i.Unmarshal([]byte(s))
 }
 
 // MarshalJSON defines custom encoding scheme

--- a/math/int_test.go
+++ b/math/int_test.go
@@ -2,6 +2,7 @@ package math_test
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -394,6 +395,14 @@ func (s *intTestSuite) TestIntEq() {
 	s.Require().True(resp)
 	_, resp, _, _, _ = math.IntEq(s.T(), math.OneInt(), math.ZeroInt())
 	s.Require().False(resp)
+}
+
+func (s *intTestSuite) TestIntXmlMarshalRoundTrip() {
+	u1 := math.NewInt(256)
+	marshalResult, _ := xml.Marshal(u1)
+	u2 := math.Int{}
+	xml.Unmarshal(marshalResult, &u2)
+	s.Require().Equal(u1, u2)
 }
 
 func TestRoundTripMarshalToInt(t *testing.T) {

--- a/math/uint.go
+++ b/math/uint.go
@@ -1,6 +1,7 @@
 package math
 
 import (
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"math/big"
@@ -136,6 +137,21 @@ func MaxUint(u1, u2 Uint) Uint { return NewUintFromBigInt(max(u1.i, u2.i)) }
 
 // Human readable string
 func (u Uint) String() string { return u.i.String() }
+
+// MarshalXML defines custom encoding for xml Marshaler
+func (u Uint) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(u.String(), start)
+}
+
+// UnmarshalXML defines custom decoding for xml Marshaler
+func (u *Uint) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var s string
+	if err := d.DecodeElement(&s, &start); err != nil {
+		return err
+	}
+	*u = NewUintFromString(s)
+	return nil
+}
 
 // MarshalJSON defines custom encoding scheme
 func (u Uint) MarshalJSON() ([]byte, error) {

--- a/math/uint_test.go
+++ b/math/uint_test.go
@@ -1,6 +1,7 @@
 package math_test
 
 import (
+	"encoding/xml"
 	"fmt"
 	"math"
 	"math/big"
@@ -376,4 +377,12 @@ func (s *uintTestSuite) TestUintBigEndian() {
 
 	s.Require().Equal(u1, u2)
 
+}
+
+func (s *uintTestSuite) TestUintXmlMarshalRoundTrip() {
+	u1 := sdkmath.NewUint(256)
+	marshalResult, _ := xml.Marshal(u1)
+	u2 := sdkmath.Uint{}
+	xml.Unmarshal(marshalResult, &u2)
+	s.Require().Equal(u1, u2)
 }

--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -10,6 +10,6 @@ const (
 	// Pampas is the upgrade name for Pampas upgrade
 	Pampas = "Pampas"
 
-	// Eddystone is the upgrade name for Eddystone upgrade
-	Eddystone = "Eddystone"
+	// Manchurian is the upgrade name for Manchurian upgrade
+	Manchurian = "Manchurian"
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -16,8 +16,8 @@ const (
 	// Pampas is the upgrade name for Pampas upgrade
 	Pampas = types.Pampas
 
-	// Eddystone is the upgrade name for Eddystone upgrade
-	Eddystone = types.Eddystone
+	// Manchurian is the upgrade name for Manchurian upgrade
+	Manchurian = types.Manchurian
 )
 
 // The default upgrade config for networks


### PR DESCRIPTION
### Description
This PR merge develop to master for v1.2.0

### Rationale
This release introduce the Manchurian upgrade to the testnet.

Chores:
* [#365](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/365) chore: add xml marshal for Int type
* [#364](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/364) chore: add xml marshal for UInt type


### Example

None
### Changes

None