### PR TITLE
feat: enable Manchurian hardfork to testnet

### DIFF
--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -42,6 +42,10 @@ var (
 		Name:   Pampas,
 		Height: 2427233,
 		Info:   "Pampas hardfork",
+	}).SetPlan(&Plan{
+		Name:   Manchurian,
+		Height: 3590153,
+		Info:   "Manchurian hardfork",
 	})
 )
 


### PR DESCRIPTION
Description
enable `Manchurian` hardfork to testnet

Rationale
1702535422 (2023-12-14 06:30:22 +UTC)- block: 3223931 [greenfieldscan](https://testnet.greenfieldscan.com/block/3223931)

Target Hardfork time:
1703487600 (2023-12-25 07:00:00 +UTC)

AvgBlockTime: 2.6s
(1703487600 - 1702535422)/2.6 + 3223931 ~= 3,590,153

Example
N/A

Changes
Notable changes:
- upgrade
