### PR TITLE
feat: modify Manchurian hardfork height of testnet

### DIFF
--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -44,7 +44,7 @@ var (
 		Info:   "Pampas hardfork",
 	}).SetPlan(&Plan{
 		Name:   Manchurian,
-		Height: 3590153,
+		Height: 3922485,
 		Info:   "Manchurian hardfork",
 	})
 )


### PR DESCRIPTION
### Description

This pr is to modify the `Manchurian` hardfork height of testnet

### Rationale

2023-12-25 07:07:38 +UTC- block: 3590185 [greenfieldscan](https://testnet.greenfieldscan.com/block/3590185)

Target Hardfork time:
2024-01-04 07:00:00 +UTC

AvgBlockTime: 2.6s
(10 * 86400) / 2.6 + 3590259 ~= 3922485

Example
N/A

Changes
Notable changes:
- modify the `Manchurian` hardfork height of testnet
