### PR TITLE
feat: introduce the Manchurian upgrade to the mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Features:
 * [#368](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/368) feat: introduce the Hulunbeier upgrade
 * [#376](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/376) feat: introduces hulunbeierPatch upgrade
 
+## v1.2.2
+This release introduce the Manchurian upgrade to the mainnet.
+
+Features:
+* [#385](https://github.com/bnb-chain/greenfield/pull/385) feat: introduce the Manchurian upgrade to the mainnet
+
 ## v1.2.1
 This release changes the Manchurian upgrade height of testnet.
 

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -36,6 +36,10 @@ var (
 		Name:   Pampas,
 		Height: 2006197,
 		Info:   "Pampas hardfork",
+	}).SetPlan(&Plan{
+		Name:   Manchurian,
+		Height: 3426973,
+		Info:   "Manchurian hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"


### PR DESCRIPTION
Description
enable Manchurian hardfork to mainnet

Rationale
1704423531 (2024/1/05 02:58:51 AM +UTC)- block: 3055870 ([greenfieldscan](https://greenfieldscan.com/block/3055870))

Target Hardfork time:
1705388400 (2024/01/16 07:00:00 +UTC)

AvgBlockTime: 2.6s
(1705388400 - 1704423531)/2.6 + 3055870 ~= `3,426,973`

Example
N/A

Changes
Notable changes:
- upgrade
