### PR TITLE
fix: module consensus version is not correctly set when upgrade after state sync

### DIFF
--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -324,6 +324,12 @@ func (k Keeper) HasHandler(name string) bool {
 
 // ApplyUpgrade will execute the handler associated with the Plan and mark the plan as done.
 func (k Keeper) ApplyUpgrade(ctx sdk.Context, plan types.Plan) {
+	err := k.InitUpgraded(ctx)
+	if err != nil {
+		ctx.Logger().Error("failed to init upgraded", "err", err)
+		return
+	}
+
 	initializer := k.upgradeInitializer[plan.Name]
 
 	if initializer != nil {


### PR DESCRIPTION
### Description

Fix upgrade initializers are not called when state sync.

### Rationale

If pre initializers are not called, it will lead to apphash mismatch issue. For example,

When doing migration, the to version (will be stored) is read from app.
```golang
toVersion := uint64(0)
if module, ok := module.(HasConsensusVersion); ok {
	toVersion = module.ConsensusVersion()
}
...

updatedVM[moduleName] = toVersion
```

However, when doing state sync, it will not call all previous upgrade initializers, leading to `toVersion` is not correct.

### Example

NA

### Changes

Notable changes: 
* upgrade handler

### Potential Impacts
