### PR TITLE
release: prepare for release 1.3.0

### DIFF
--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -43,6 +43,14 @@ var (
 		Name:   Manchurian,
 		Height: 3426973,
 		Info:   "Manchurian hardfork",
+	}).SetPlan(&Plan{
+		Name:   Hulunbeier,
+		Height: 4653883,
+		Info:   "Hulunbeier hardfork",
+	}).SetPlan(&Plan{
+		Name:   HulunbeierPatch,
+		Height: 4653883,
+		Info:   "Hulunbeier hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -58,6 +66,14 @@ var (
 		Name:   Manchurian,
 		Height: 3922485,
 		Info:   "Manchurian hardfork",
+	}).SetPlan(&Plan{
+		Name:   Hulunbeier,
+		Height: 4849568,
+		Info:   "Hulunbeier hardfork",
+	}).SetPlan(&Plan{
+		Name:   HulunbeierPatch,
+		Height: 4849568,
+		Info:   "Hulunbeier hardfork",
 	})
 )
 


### PR DESCRIPTION
### Description

this pr prepares for release v1.3.0 and config the Hardfork block height in Testnet and Mainnet. 

## Rationale

### **Testnet:**
Height: 4512546.  Timestamp  1705894544 (2024-1-22 03:35:44 AM +UTC) https://testnet.greenfieldscan.com/block/4512546

Target Hardfork time:
1706770800 (2024/02/01 07:00:00 +UTC). 

AvgBlockTime: 2.6s

**Target Hardfork height:**
(1706770800 - 1705894544)/2.6 + 4512546  ~= `4849568`


### **Mainnet:**
Height: 3623490. Timestamp 1705906178 (2024-1-22 06:49:38 AM +UTC) https://greenfieldscan.com/block/3623490

Target Hardfork time:
1708585200 (2024/2/22 7:00 am UTC). 

AvgBlockTime: 2.6s
**Target Hardfork height:**
(1708585200 - 1705906178)/2.6 + 3623490  ~= `4653883`