### PR TITLE
doc:  add change log for release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## V1.4.0
+This release introduces the Ural upgrade.
+
+Features:
+* [#388](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/388) feat: introduce the Ural upgrade
+
+BUGFIX
+* [#391](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/391) fix: module consensus version is not correctly set when upgrade after state sync
+
+
 ## v1.3.0
 This release introduces the Hulunbeier upgrade.
 


### PR DESCRIPTION
### Description
just add change log for v1.4.0
### Rationale

Features:
* [#388](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/388) feat: introduce the Ural upgrade

BUGFIX
* [#391](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/391) fix: module consensus version is not correctly set when upgrade after state sync

### Example
None
### Changes
None