### PR TITLE
release: prepare for the v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## V1.4.0
+This release introduces the Ural upgrade.
+
+Features:
+* [#388](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/388) feat: introduce the Ural upgrade
+
+BUGFIX
+* [#391](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/391) fix: module consensus version is not correctly set when upgrade after state sync
+
+
 ## v1.3.0
 This release introduces the Hulunbeier upgrade.
 

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -324,6 +324,12 @@ func (k Keeper) HasHandler(name string) bool {
 
 // ApplyUpgrade will execute the handler associated with the Plan and mark the plan as done.
 func (k Keeper) ApplyUpgrade(ctx sdk.Context, plan types.Plan) {
+	err := k.InitUpgraded(ctx)
+	if err != nil {
+		ctx.Logger().Error("failed to init upgraded", "err", err)
+		return
+	}
+
 	initializer := k.upgradeInitializer[plan.Name]
 
 	if initializer != nil {


### PR DESCRIPTION
### Description
prepare for the v1.4.0 release

### Rationale
This release introduces the Ural upgrade.

Features:
* [#388](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/388) feat: introduce the Ural upgrade

BUGFIX
* [#391](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/391) fix: module consensus version is not correctly set when upgrade after state sync


### Example

None

### Changes
None