### PR TITLE
feat: prepare for release v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.0
 
-	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.1.1-0.20240126083037-13fc717dc658
+	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.2.0
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsy
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield-cometbft v1.1.1-0.20240126083037-13fc717dc658 h1:x9v/GOYZgsYsUbTUkOY0DoBrqbqrywZioLdT2wCPLy4=
-github.com/bnb-chain/greenfield-cometbft v1.1.1-0.20240126083037-13fc717dc658/go.mod h1:WVOEZ59UYM2XePQH47/IQfcInspDn8wbRXhFSJrbU1c=
+github.com/bnb-chain/greenfield-cometbft v1.2.0 h1:LTStppZS9WkVj0TfEYKkk5OAQDGfYlUefWByr7Zr018=
+github.com/bnb-chain/greenfield-cometbft v1.2.0/go.mod h1:WVOEZ59UYM2XePQH47/IQfcInspDn8wbRXhFSJrbU1c=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
 github.com/bnb-chain/greenfield-iavl v0.20.1 h1:y3L64GU99otNp27/xLVBTDbv4eroR6CzoYz0rbaVotM=

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -51,6 +51,10 @@ var (
 		Name:   HulunbeierPatch,
 		Height: 4653883,
 		Info:   "Hulunbeier hardfork",
+	}).SetPlan(&Plan{
+		Name:   Ural,
+		Height: 5347231,
+		Info:   "Ural hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -74,6 +78,10 @@ var (
 		Name:   HulunbeierPatch,
 		Height: 4849568,
 		Info:   "Hulunbeier hardfork",
+	}).SetPlan(&Plan{
+		Name:   Ural,
+		Height: 5733436,
+		Info:   "Ural hardfork",
 	})
 )
 

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -80,7 +80,7 @@ var (
 		Info:   "Hulunbeier hardfork",
 	}).SetPlan(&Plan{
 		Name:   Ural,
-		Height: 5733436,
+		Height: 5761391,
 		Info:   "Ural hardfork",
 	})
 )


### PR DESCRIPTION
### Description
update cometbft dependency version to v1.2.0, prepare for Ural upgrade

### **Testnet:**
Height: 5491156.  Timestamp  1708487387 (2024-2-21 03:49:47 AM +UTC) https://testnet.greenfieldscan.com/block/5491156

Target Hardfork time:
1709190000 (2024/02/29 07:00:00 +UTC). 

AvgBlockTime: 2.6s

**Target Hardfork height:**
(1709190000 - 1708487387)/2.6 + 5491156  ~= `5761391`


### **Mainnet:**
Height: 4611855. Timestamp 1708487620 (2024-2-21 03:53:40 AM +UTC) https://greenfieldscan.com/block/4611855

Target Hardfork time:
1710399600 (2024/3/14 7:00 am UTC). 

AvgBlockTime: 2.6s

**Target Hardfork height:**
(1710399600 - 1708487620)/2.6 + 4611855  ~= `5347231`

### Changes

Notable changes:
* update cometbft dependency version to v1.2.0
* add ural upgrade plan
* ...