### PR TITLE
fix: sync failed from genesis

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,11 @@
 test-integration:
-	go test ./integration/... -timeout 30m
+	go test -failfast ./integration/... -timeout 30m
 
 test-integration-cov:
-	go test ./integration/... -timeout 30m -coverpkg=../... -coverprofile=integration-profile.out -covermode=atomic
+	go test -failfast ./integration/... -timeout 30m -coverpkg=../... -coverprofile=integration-profile.out -covermode=atomic
 
 test-e2e:
-	go test ./e2e/... -mod=readonly -timeout 30m -race -tags='e2e'
+	go test ./e2e/... -failfast -mod=readonly -timeout 30m -race -tags='e2e'
 
 test-e2e-cov:
-	go test ./e2e/... -mod=readonly -timeout 30m -race -tags='e2e' -coverpkg=../... -coverprofile=e2e-profile.out -covermode=atomic
+	go test ./e2e/... -failfast -mod=readonly -timeout 30m -race -tags='e2e' -coverpkg=../... -coverprofile=e2e-profile.out -covermode=atomic

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -434,7 +434,7 @@ func (k Keeper) IsUpgraded(ctx sdk.Context, name string) bool {
 
 // InitUpgraded execute the upgrade initializer that the upgrade is already applied.
 func (k Keeper) InitUpgraded(ctx sdk.Context) error {
-	iter := storetypes.KVStorePrefixIterator(ctx.KVStore(k.storeKey), []byte{types.DoneByte})
+	iter := storetypes.KVStorePrefixIterator(ctx.KVStoreWithZeroRead(k.storeKey), []byte{types.DoneByte})
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {


### PR DESCRIPTION
### Description
Sync blocks starting from genesis will fail on the first block.

```
{"level":"error","module":"server","module":"blockchain","err":"wrong Block.Header.LastResultsHash.  Expected 6908820926ED68A842B585BD1927F47F3853DC66EBA2A66AE899688848963151, got 007F040A8F62D6EEDD4B62FD11B145756DD5E6D47286280839DA676390F8F57C","time":"2024-03-07T15:07:17+08:00","message":"Error in validation"}
```

### Rationale

After `Nagqu`, the KV read gas will be set to 0 (https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/300).
However, "InitUpgraded" per block was added in `v1.4.0`(https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/391), if this happens before the `Nagqu` upgrade or at the same height, this will cause the gas reading to increase, causing `begin_block_extra_data`, ` end_block_extra_data` produces different results

### Example

n/a

### Changes

Notable changes:
* upgrade module