### PR TITLE
feat: set up Pawnee upgrade for Mainnet and Testnet

### DIFF
--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -58,6 +58,10 @@ var (
 		Name:   Ural,
 		Height: 5347231,
 		Info:   "Ural hardfork",
+	}).SetPlan(&Plan{
+		Name:   Pawnee,
+		Height: 6239520,
+		Info:   "Pawnee hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -85,6 +89,10 @@ var (
 		Name:   Ural,
 		Height: 5761391,
 		Info:   "Ural hardfork",
+	}).SetPlan(&Plan{
+		Name:   Pawnee,
+		Height: 6623127,
+		Info:   "Pawnee hardfork",
 	})
 )
 


### PR DESCRIPTION
### Description

**Testnet:**
Height: 6152570.  Timestamp  1710299353 (13 March 2024 03:09:13)

Target Hardfork time:
1711522800 Wednesday, 27 March 2024 07:00:00

AvgBlockTime: 2.6s

Target Hardfork height
(1711522800 - 1710299353)/2.6 + 6152570  ~= `6623127`



**Mainnet:**
Height: 5303836. Timestamp 1710299621 (13 March 2024 03:13:41)

Target Hardfork time:
1712732400 (10 April 2024 07:00:00). 

AvgBlockTime: 2.6s

(1712732400 - 1710299621)/2.6 + 5303836  ~= `6239520`

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...