### PR TITLE
feat: add support for `PrintMsgMarshalBytes`

### DIFF
--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -26,4 +26,7 @@ const (
 
 	// Serengeti is the upgrade name for Serengeti upgrade
 	Serengeti = "Serengeti"
+
+	// Erdos is the upgrade name for Erdos upgrade
+	Erdos = "Erdos"
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -32,6 +32,9 @@ const (
 
 	// Serengeti is the upgrade name for Serengeti upgrade
 	Serengeti = types.Serengeti
+
+	// Erdos is the upgrade name for Erdos upgrade
+	Erdos = types.Erdos
 )
 
 // The default upgrade config for networks


### PR DESCRIPTION
### Description

This pr is to add support for `PrintMsgMarshalBytes` in the cmd

### Rationale

This is to help users generate msg bytes which could be used in [BEP363](https://github.com/bnb-chain/BEPs/pull/363)

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add support for `PrintMsgMarshalBytes` in the cmd