### PR TITLE
feat: set up Serengeti upgrade for Mainnet and Testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## V1.6.0
+This release introduces the Serengeti upgrade.
+
+Features:
+* [#400](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/400) feat: add upgrade Serengeti
+
+
+## V1.5.0
+This release introduces the Pawnee upgrade.
+
+Features:
+* [#396](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/396) feat: introduce Pawnee upgrade
+
+BUGFIX
+* [#401](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/401) fix: sync failed from genesis
+
+
 ## V1.4.0
 This release introduces the Ural upgrade.
 

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -68,6 +68,10 @@ var (
 		Name:   Pawnee,
 		Height: 6239520,
 		Info:   "Pawnee hardfork",
+	}).SetPlan(&Plan{
+		Name:   Serengeti,
+		Height: 6863285,
+		Info:   "Serengeti hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -99,6 +103,10 @@ var (
 		Name:   Pawnee,
 		Height: 6623127,
 		Info:   "Pawnee hardfork",
+	}).SetPlan(&Plan{
+		Name:   Serengeti,
+		Height: 7354695,
+		Info:   "Serengeti hardfork",
 	})
 )
 


### PR DESCRIPTION
### Description

**Testnet**:
Current Height: 6983516.  Timestamp  1712458534

Target Hardfork time:
1713423600  18 April 2024 07:00:00

AvgBlockTime: 2.6s

Target Hardfork height
(1713423600 - 1712458534)/2.6 + 6983516  ~= **7354695**


**Mainnet**:
Current Height: 6126438. Timestamp 1712458199 

Target Hardfork time:

1714374000   29 April 2024 07:00:00

AvgBlockTime: 2.6s

(1714374000 - 1712458199)/2.6 + 6126438  ~= **6863285**
### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...