### PR TITLE
docs: set up Erdos hardfork and  add change log 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## V1.7.0
+This release introduces the Erdos upgrade
+
+Features:
+* [#417](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/417) feat: feat: add multi message support for greenfield crosschain app
+
+Fixes:
+* [#422](https://github.com/bnb-chain/greenfield-cosmos-sdk/pull/422) fix: fix the deps security
+
+
 ## V1.6.0
 This release introduces the Serengeti upgrade.
 

--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.23.2
 
-	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.2.1-0.20240423054022-904c57ecf3ff
+	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.3.0
 	github.com/cometbft/cometbft-db => github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1
 	github.com/cosmos/iavl => github.com/bnb-chain/greenfield-iavl v0.20.1
 

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsy
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield-cometbft v1.2.1-0.20240423054022-904c57ecf3ff h1:ClDnN5TePzIrgpAAyZs6diPCXu1NqCeh93B8FtypQdg=
-github.com/bnb-chain/greenfield-cometbft v1.2.1-0.20240423054022-904c57ecf3ff/go.mod h1:0D+VPivZTeBldjtGGi9LKbBnKEO/RtMRJikie92LkYI=
+github.com/bnb-chain/greenfield-cometbft v1.3.0 h1:v3nZ16ledTZGF5Csys7fTQGZcEV78ZLUtptA9PLKMo4=
+github.com/bnb-chain/greenfield-cometbft v1.3.0/go.mod h1:0D+VPivZTeBldjtGGi9LKbBnKEO/RtMRJikie92LkYI=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
 github.com/bnb-chain/greenfield-iavl v0.20.1 h1:y3L64GU99otNp27/xLVBTDbv4eroR6CzoYz0rbaVotM=

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -72,6 +72,10 @@ var (
 		Name:   Serengeti,
 		Height: 6863285,
 		Info:   "Serengeti hardfork",
+	}).SetPlan(&Plan{
+		Name:   Erdos,
+		Height: 7627845,
+		Info:   "Erdos hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -107,6 +111,10 @@ var (
 		Name:   Serengeti,
 		Height: 7354695,
 		Info:   "Serengeti hardfork",
+	}).SetPlan(&Plan{
+		Name:   Erdos,
+		Height: 8086093,
+		Info:   "Erdos hardfork",
 	})
 )
 


### PR DESCRIPTION
### Description

1. config the Erdos hardfork height for testnet and mainnet. 
```
Testnet:
Current Height: 7715960.  Timestamp  1714362054

Target Hardfork time:
1715324400  10 May 2024 07:00:00.     UTC

AvgBlockTime: 2.6s

Target Hardfork height
(1715324400 - 1714362054)/2.6 + 7715960  ~= 8086093

Mainnet:
Height: 6858994. Timestamp 1714362187 

Target Hardfork time:

1716361200   22 May 2024 07:00:00

AvgBlockTime: 2.6s

(1716361200 - 1714362187)/2.6 + 6858994  ~= 7627845
```

2. add change log 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...