### PR TITLE
feat: set up hardfork height for Erdos

### DIFF
--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -74,7 +74,7 @@ var (
 		Info:   "Serengeti hardfork",
 	}).SetPlan(&Plan{
 		Name:   Erdos,
-		Height: 7627845,
+		Height: 7861456,
 		Info:   "Erdos hardfork",
 	})
 
@@ -113,7 +113,7 @@ var (
 		Info:   "Serengeti hardfork",
 	}).SetPlan(&Plan{
 		Name:   Erdos,
-		Height: 8086093,
+		Height: 8285529,
 		Info:   "Erdos hardfork",
 	})
 )


### PR DESCRIPTION
### Description

set up hardfork height for Erdos

```
Testnet:
Current Height: 7753470.  Timestamp  1714459447

Target Hardfork time:
1715842800  16 May 2024 07:00:00.     UTC

AvgBlockTime: 2.6s

Target Hardfork height
(1715842800 - 1714459447)/2.6 + 7753470  ~= 8285529



Mainnet:
Height: 6897702. Timestamp 1714460240 

Target Hardfork time:

1716966000   29 May 2024 07:00:00

AvgBlockTime: 2.6s

(1716966000 - 1714460240)/2.6 + 6897702  ~= 7861456
```



### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...