### PR TITLE
release: update the block height for erdos

### DIFF
--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -113,7 +113,7 @@ var (
 		Info:   "Serengeti hardfork",
 	}).SetPlan(&Plan{
 		Name:   Erdos,
-		Height: 8285529,
+		Height: 8116724,
 		Info:   "Erdos hardfork",
 	})
 )


### PR DESCRIPTION
### Description

Testnet:
Current Height: 8099041.  Timestamp  1715359522

Target Hardfork time:
1715410800  11 May 2024 07:00:00.     UTC

AvgBlockTime: 2.9s

Target Hardfork height
(1715410800 - 1715359522)/2.9 + 8099041  ~= 8116724