### PR TITLE
feat: set up hardfork height and add CHANGELOG.md 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## V1.8.0
+This release introduces the Veld upgrade
+
 ## V1.7.0
 This release introduces the Erdos upgrade
 

--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -29,4 +29,7 @@ const (
 
 	// Erdos is the upgrade name for Erdos upgrade
 	Erdos = "Erdos"
+
+	// Veld is the upgrade name for Veld upgrade
+	Veld = "Veld"
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -35,6 +35,9 @@ const (
 
 	// Erdos is the upgrade name for Erdos upgrade
 	Erdos = types.Erdos
+
+	// Veld is the upgrade name for Veld upgrade
+	Veld = types.Veld
 )
 
 // The default upgrade config for networks
@@ -76,6 +79,10 @@ var (
 		Name:   Erdos,
 		Height: 7861456,
 		Info:   "Erdos hardfork",
+	}).SetPlan(&Plan{
+		Name:   Veld,
+		Height: 9030588,
+		Info:   "Veld hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -115,6 +122,10 @@ var (
 		Name:   Erdos,
 		Height: 8116724,
 		Info:   "Erdos hardfork",
+	}).SetPlan(&Plan{
+		Name:   Veld,
+		Height: 9379516,
+		Info:   "Veld hardfork",
 	})
 )
 


### PR DESCRIPTION
### Description

Testnet:
Current Height: 8518307. Timestamp 1716540978

Target Hardfork time:
1718694000 18 June 2024 07:00:00

AvgBlockTime: 2.5s

Target Hardfork height
(1718694000 - 1716540978)/2.5 + 8518307 ~= 9379516

Mainnet:
Current Height: 7720024. Timestamp 1716540791

Target Hardfork time:

1719817200 1 July 2024 07:00:00

AvgBlockTime: 2.5s

(1719817200 - 1716540791)/2.5 + 7720024 ~= 9030588


### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* set up hardfork height and add CHANGELOG.md 