### PR TITLE
feat: update the block height for veld

### DIFF
--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -81,7 +81,7 @@ var (
 		Info:   "Erdos hardfork",
 	}).SetPlan(&Plan{
 		Name:   Veld,
-		Height: 9030588,
+		Height: 9269910,
 		Info:   "Veld hardfork",
 	})
 
@@ -124,7 +124,7 @@ var (
 		Info:   "Erdos hardfork",
 	}).SetPlan(&Plan{
 		Name:   Veld,
-		Height: 9379516,
+		Height: 9581218,
 		Info:   "Veld hardfork",
 	})
 )


### PR DESCRIPTION
### Description

Testnet:
Current Height: 9115096. Timestamp 1718086884
<img width="1108" alt="image" src="https://github.com/bnb-chain/greenfield-cosmos-sdk/assets/122767193/e2c9ba19-f2f2-4d16-9d6b-a6db15065df6">
<img width="800" alt="image" src="https://github.com/bnb-chain/greenfield-cosmos-sdk/assets/122767193/c089a625-7071-486a-8307-ba58a7e65a11">


Target Hardfork time:
1719298800 25 June 2024 07:00:00

AvgBlockTime: 2.6s

Target Hardfork height
(1719298800 - 1718086884)/2.6 + 9115096 ~= 9581218

Mainnet:
Current Height: 8335904. Timestamp 1718086984
<img width="1063" alt="image" src="https://github.com/bnb-chain/greenfield-cosmos-sdk/assets/122767193/8e636204-10ec-4feb-889f-7ae289cf24a8">
<img width="759" alt="image" src="https://github.com/bnb-chain/greenfield-cosmos-sdk/assets/122767193/dd5b0de7-0d67-413c-b523-0e06f532d083">


Target Hardfork time:

1720422000 8 July 2024 07:00:00

AvgBlockTime: 2.5s

(1720422000 - 1718086984)/2.5 + 8335904 ~= 9269910


### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* set up hardfork height and add CHANGELOG.md 