### PR TITLE
feat: introduce the Savanna upgrade

### DIFF
--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -38,4 +38,7 @@ const (
 
 	// Altai is the upgrade name for Altai upgrade
 	Altai = "Altai"
+
+	// Savanna is the upgrade name for Savanna upgrade
+	Savanna = "Savanna"
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -102,7 +102,7 @@ var (
 		Info:   "Altai hardfork",
 	}).SetPlan(&Plan{
 		Name:   Savanna,
-		Height: 14679048,
+		Height: 14667574,
 		Info:   "Savanna hardfork",
 	})
 
@@ -157,7 +157,7 @@ var (
 		Info:   "Altai hardfork",
 	}).SetPlan(&Plan{
 		Name:   Savanna,
-		Height: 14702349,
+		Height: 14691233,
 		Info:   "Savanna hardfork",
 	})
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -44,6 +44,9 @@ const (
 
 	// Altai is the upgrade name for Altai upgrade
 	Altai = types.Altai
+
+	// Savanna is the upgrade name for Savanna upgrade
+	Savanna = types.Savanna
 )
 
 // The default upgrade config for networks
@@ -97,6 +100,10 @@ var (
 		Name:   Altai,
 		Height: 11917971,
 		Info:   "Altai hardfork",
+	}).SetPlan(&Plan{
+		Name: Savanna,
+		// todo: height
+		Info: "Savanna hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -148,6 +155,10 @@ var (
 		Name:   Altai,
 		Height: 12513708,
 		Info:   "Altai hardfork",
+	}).SetPlan(&Plan{
+		Name: Savanna,
+		// todo: height
+		Info: "Savanna hardfork",
 	})
 )
 

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -101,9 +101,9 @@ var (
 		Height: 11917971,
 		Info:   "Altai hardfork",
 	}).SetPlan(&Plan{
-		Name: Savanna,
-		// todo: height
-		Info: "Savanna hardfork",
+		Name:   Savanna,
+		Height: 14679048,
+		Info:   "Savanna hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -156,9 +156,9 @@ var (
 		Height: 12513708,
 		Info:   "Altai hardfork",
 	}).SetPlan(&Plan{
-		Name: Savanna,
-		// todo: height
-		Info: "Savanna hardfork",
+		Name:   Savanna,
+		Height: 14702349,
+		Info:   "Savanna hardfork",
 	})
 )
 


### PR DESCRIPTION
### Description

Introduce a new hardfork - Savanna.

### Rationale

Add new hardfork.

#### Testnet
Current Height: 14358790. Timestamp 1732158715

Target Hardfork time:
1733122800 02 December 2024 07:00:00 UTC

AvgBlockTime: 2.9s

Target Hardfork height
(1733122800 - 1732158715)/2.9 + 14358790 ~= `14691233`

#### Mainnet
Current Height: 13939220. Timestamp 1732158632

Target Hardfork time:
1733986800 12 December 2024 07:00:00 UTC

AvgBlockTime: 2.51s

Target Hardfork height
(1733986800 - 1732158632)/2.51 + 13939220 ~= `14667574`

The Greenfield Testnet is expected to have a scheduled hardfork upgrade named Savanna
 at block height 14691233. The current block generation speed forecasts this to occur around 02 December 2024 07:00:00 UTC

The Greenfield Mainnet is expected to have a scheduled hardfork upgrade named Savanna
 at block height 14667574. The current block generation speed forecasts this to occur around 12 December 2024 07:00:00 UTC

### Example

NA

### Changes

Notable changes:
* hardfork