### PR TITLE
feat: introduce the Tundra upgrade

### DIFF
--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -41,4 +41,7 @@ const (
 
 	// Savanna is the upgrade name for Savanna upgrade
 	Savanna = "Savanna"
+
+	// Tundra is the upgrade name for Tundra upgrade
+	Tundra = "Tundra"
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -109,7 +109,7 @@ var (
 		Info:   "Savanna hardfork",
 	}).SetPlan(&Plan{
 		Name:   Tundra,
-		Height: 24002835,
+		Height: 25213033,
 		Info:   "Tundra hardfork",
 	})
 
@@ -168,7 +168,7 @@ var (
 		Info:   "Savanna hardfork",
 	}).SetPlan(&Plan{
 		Name:   Tundra,
-		Height: 25213033,
+		Height: 24002835,
 		Info:   "Tundra hardfork",
 	})
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -47,6 +47,9 @@ const (
 
 	// Savanna is the upgrade name for Savanna upgrade
 	Savanna = types.Savanna
+
+	// Tundra is the upgrade name for Tundra upgrade
+	Tundra = types.Tundra
 )
 
 // The default upgrade config for networks
@@ -104,6 +107,10 @@ var (
 		Name:   Savanna,
 		Height: 14667574,
 		Info:   "Savanna hardfork",
+	}).SetPlan(&Plan{
+		Name:   Tundra,
+		Height: 24002835,
+		Info:   "Tundra hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -159,6 +166,10 @@ var (
 		Name:   Savanna,
 		Height: 14691233,
 		Info:   "Savanna hardfork",
+	}).SetPlan(&Plan{
+		Name:   Tundra,
+		Height: 25213033,
+		Info:   "Tundra hardfork",
 	})
 )
 


### PR DESCRIPTION

### Description

Introduce a new hardfork - Tundra.

### Rationale

Add new hardfork.

#### Testnet
Current Height: 23997400. Timestamp 1760409438   (2025-10-14 02:37:18 AM +UTC) 

Target Hardfork time:
1760425200 14 Oct 2025 07:00:00 UTC

AvgBlockTime: 2.9s

Target Hardfork height
(1760425200 - 1760409438)/2.9 + 23997400 ~= `24002835`

#### Mainnet
Current Height: 25176924. Timestamp 1760410165 (2025-10-14 02:49:25 AM +UTC)

Target Hardfork time:
1760500800 15 Oct 2025 04:00:00 UTC

AvgBlockTime: 2.51s

Target Hardfork height
(1760500800 - 1760410165)/2.51 + 25176924 ~= `25213033`

The Greenfield Testnet is expected to have a scheduled hardfork upgrade named Tundra
 at block height 24002835. The current block generation speed forecasts this to occur around 14 Oct 2025 07:00:00 UTC

The Greenfield Mainnet is expected to have a scheduled hardfork upgrade named Tundra
 at block height 25213033. The current block generation speed forecasts this to occur around 15 Oct 2025 04:00:00 UTC

### Example

NA

### Changes

Notable changes:
* hardfork