### PR TITLE
feat: introduce the Tundra upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,19 +29,19 @@ jobs:
         run: go list ./... > pkgs.txt
       - name: Split pkgs into 4 files
         run: split -d -n l/4 pkgs.txt pkgs.txt.part.
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-00"
           path: ./pkgs.txt.part.00
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-01"
           path: ./pkgs.txt.part.01
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-02"
           path: ./pkgs.txt.part.02
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "${{ github.sha }}-03"
           path: ./pkgs.txt.part.03
@@ -70,14 +70,14 @@ jobs:
             go.sum
             **/go.mod
             **/go.sum
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
       - name: test & coverage report creation
         if: env.GIT_DIFF
         run: |
           cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -race -timeout 60m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='ledger test_ledger_mock'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-${{ matrix.part }}-coverage"
@@ -108,7 +108,7 @@ jobs:
         if: env.GIT_DIFF
         run: |
           make test-integration-cov
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-integration-coverage"
@@ -139,7 +139,7 @@ jobs:
         if: env.GIT_DIFF
         run: |
           make test-e2e-cov
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-e2e-coverage"
@@ -159,27 +159,27 @@ jobs:
             go.sum
             **/go.mod
             **/go.sum
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-00-coverage"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-01-coverage"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-02-coverage"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-03-coverage"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-integration-coverage"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-e2e-coverage"
@@ -268,9 +268,10 @@ jobs:
         if: env.GIT_DIFF
         run: |
           cd simapp
-          go test -mod=readonly -timeout 60m -coverprofile=coverage.out -covermode=atomic -tags='norace ledger test_ledger_mock rocksdb_build' ./...
+          go test -mod=readonly -timeout 30m -tags='norace ledger test_ledger_mock rocksdb_build' ./...
       - name: tests simapp v1
         if: env.GIT_DIFF
         run: |
           cd simapp
-          go test -mod=readonly -timeout 60m -tags='app_v1 norace ledger test_ledger_mock rocksdb_build' ./...
+          go test -mod=readonly -timeout 30m -tags='app_v1 norace ledger test_ledger_mock rocksdb_build' ./...
+

--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -41,4 +41,7 @@ const (
 
 	// Savanna is the upgrade name for Savanna upgrade
 	Savanna = "Savanna"
+
+	// Tundra is the upgrade name for Tundra upgrade
+	Tundra = "Tundra"
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -168,7 +168,7 @@ var (
 		Info:   "Savanna hardfork",
 	}).SetPlan(&Plan{
 		Name:   Tundra,
-		Height: 24002835,
+		Height: 24007800,
 		Info:   "Tundra hardfork",
 	})
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -47,6 +47,9 @@ const (
 
 	// Savanna is the upgrade name for Savanna upgrade
 	Savanna = types.Savanna
+
+	// Tundra is the upgrade name for Tundra upgrade
+	Tundra = types.Tundra
 )
 
 // The default upgrade config for networks
@@ -104,6 +107,10 @@ var (
 		Name:   Savanna,
 		Height: 14667574,
 		Info:   "Savanna hardfork",
+	}).SetPlan(&Plan{
+		Name:   Tundra,
+		Height: 25213033,
+		Info:   "Tundra hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -159,6 +166,10 @@ var (
 		Name:   Savanna,
 		Height: 14691233,
 		Info:   "Savanna hardfork",
+	}).SetPlan(&Plan{
+		Name:   Tundra,
+		Height: 24002835,
+		Info:   "Tundra hardfork",
 	})
 )
 


### PR DESCRIPTION

### Description

Introduce a new hardfork - Tundra.

### Rationale

Add new hardfork.

#### Testnet
Current Height: 23997400. Timestamp 1760409438   (2025-10-14 02:37:18 AM +UTC) 

Target Hardfork time:
1760439600 14 Oct 2025 11:00:00 UTC

AvgBlockTime: 2.9s

Target Hardfork height
(1760439600 - 1760409438)/2.9 + 23997400 ~= `24007800`

#### Mainnet
Current Height: 25176924. Timestamp 1760410165 (2025-10-14 02:49:25 AM +UTC)

Target Hardfork time:
1760500800 15 Oct 2025 04:00:00 UTC

AvgBlockTime: 2.51s

Target Hardfork height
(1760500800 - 1760410165)/2.51 + 25176924 ~= `25213033`

The Greenfield Testnet is expected to have a scheduled hardfork upgrade named Tundra
 at block height 24007800. The current block generation speed forecasts this to occur around 14 Oct 2025 11:00:00 UTC

The Greenfield Mainnet is expected to have a scheduled hardfork upgrade named Tundra
 at block height 25213033. The current block generation speed forecasts this to occur around 15 Oct 2025 04:00:00 UTC

### Example

NA

### Changes

Notable changes:
* hardfork