### PR TITLE
feat: validator size non zero

### DIFF
--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -205,6 +205,9 @@ func (k Keeper) getInturnRelayer(ctx sdk.Context, relayerInterval uint64, claimS
 	validators := historicalInfo.Valset
 
 	validatorsSize := len(validators)
+	if validatorsSize == 0 {
+		return nil, nil, sdkerrors.Wrapf(types.ErrValidatorSet, "empty validator set in historical info")
+	}
 
 	// totalIntervals is sum of intervals from all relayers
 	totalIntervals := relayerInterval * uint64(validatorsSize)


### PR DESCRIPTION
### Description

We should fail fast with a clear module error when validator data is present but unusable, instead of continuing and crashing later. This makes oracle relayer selection safer and easier to diagnose.

### Rationale
The function now handles an empty validator set gracefully and returns a deterministic error instead of risking runtime panic-like behavior in interval/index calculation.

### Example
N/A

### Changes

Notable changes:
* keeper add one more validatorsSize check