### PR TITLE
feat(upgrade): introduce the Prairie upgrade

### DIFF
--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -44,4 +44,7 @@ const (
 
 	// Tundra is the upgrade name for Tundra upgrade
 	Tundra = "Tundra"
+
+	// Prairie is the upgrade name for Prairie upgrade
+	Prairie = "Prairie"
 )

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -50,6 +50,9 @@ const (
 
 	// Tundra is the upgrade name for Tundra upgrade
 	Tundra = types.Tundra
+
+	// Prairie is the upgrade name for Prairie upgrade
+	Prairie = types.Prairie
 )
 
 // The default upgrade config for networks

--- a/x/upgrade/types/upgrade_config.go
+++ b/x/upgrade/types/upgrade_config.go
@@ -114,6 +114,10 @@ var (
 		Name:   Tundra,
 		Height: 25213033,
 		Info:   "Tundra hardfork",
+	}).SetPlan(&Plan{
+		Name:   Prairie,
+		Height: 31432100,
+		Info:   "Prairie hardfork",
 	})
 
 	TestnetChainID = "greenfield_5600-1"
@@ -173,6 +177,10 @@ var (
 		Name:   Tundra,
 		Height: 24007800,
 		Info:   "Tundra hardfork",
+	}).SetPlan(&Plan{
+		Name:   Prairie,
+		Height: 29798400,
+		Info:   "Prairie hardfork",
 	})
 )
 


### PR DESCRIPTION
### Description

Introduce a new hardfork - Prairie.

### Rationale

Add new hardfork.

#### Testnet
Current Height: 29770307. Timestamp 1775545200 (2026-04-07 07:00:00 AM +UTC)

Target Hardfork time:
1775615400 08 Apr 2026 02:30:00 UTC (10:30 UTC+8)

AvgBlockTime: 2.5s

Target Hardfork height
(1775615400 - 1775545200)/2.5 + 29770307 ~= `29798400`

#### Mainnet
Current Height: 31196659. Timestamp 1775545200 (2026-04-07 07:00:00 AM +UTC)

Target Hardfork time:
1776133800 14 Apr 2026 02:30:00 UTC (10:30 UTC+8)

AvgBlockTime: 2.5s

Target Hardfork height
(1776133800 - 1775545200)/2.5 + 31196659 ~= `31432100`

The Greenfield Testnet is expected to have a scheduled hardfork upgrade named Prairie at block height 29798400. The current block generation speed forecasts this to occur around 08 Apr 2026 02:30:00 UTC (10:30 UTC+8).

The Greenfield Mainnet is expected to have a scheduled hardfork upgrade named Prairie at block height 31432100. The current block generation speed forecasts this to occur around 14 Apr 2026 02:30:00 UTC (10:30 UTC+8).

### Example

NA

### Changes

Notable changes:
* hardfork

🤖 Generated with [Claude Code](https://claude.com/claude-code)